### PR TITLE
Feat: 로그인 페이지 Template 제작

### DIFF
--- a/src/components/templates/LoginTemplate/LoginTemplate.stories.tsx
+++ b/src/components/templates/LoginTemplate/LoginTemplate.stories.tsx
@@ -1,0 +1,20 @@
+/* eslint-disable arrow-body-style */
+import React from 'react';
+import { Meta } from '@storybook/react';
+import LoginTemplate from './LoginTemplate';
+import Typo from '../../atoms/Typo/Typo';
+
+export default {
+  component: LoginTemplate,
+  title: 'templates/LoginTemplate',
+} as Meta;
+
+export const Default = () => {
+  return (
+    <LoginTemplate
+      logo={<Typo variant="h1">Title here</Typo>}
+      input={<Typo variant="h5">Input here</Typo>}
+      button={<Typo variant="h5">Button here</Typo>}
+    />
+  );
+};

--- a/src/components/templates/LoginTemplate/LoginTemplate.tsx
+++ b/src/components/templates/LoginTemplate/LoginTemplate.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  root: {
+    padding: '5em 0',
+  },
+});
+
+type LoginTemplateProps = {
+  logo?: React.ReactNode,
+  input?: React.ReactNode,
+  button: React.ReactNode,
+};
+
+const LoginTemplate = ({
+  logo, input, button,
+// eslint-disable-next-line arrow-body-style
+}: LoginTemplateProps) => {
+  const classes = useStyles();
+
+  return (
+    <Grid container justifyContent="center">
+      <Grid
+        item
+        container
+        className={classes.root}
+        direction="column"
+        justifyContent="flex-start"
+        xs={6}
+        spacing={3}
+      >
+        <Grid item container justifyContent="center">{logo}</Grid>
+        <Grid item container justifyContent="center">{input}</Grid>
+        <Grid item container justifyContent="center">{button}</Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+LoginTemplate.defaultProps = {
+  logo: null,
+  input: null,
+};
+
+export default LoginTemplate;


### PR DESCRIPTION
## 기능에 대한 설명
초기 로그인 화면, 회원가입 직후 닉네임/프로필 사진 설정 화면, 2FA 인증 화면 등에서 사용할 수 있는 로그인 페이지 Template을 제작하였습니다.

## 테스트 (Optional)

Storybook 으로 렌더링 확인

## REFERENCE (Optional)

[Material-ui Grid](https://material-ui.com/components/grid/), [Grid-interactive](https://material-ui.com/components/grid/#interactive)

## ISSUE
close #15 
