### PR TITLE
Feat: App 상태 관리 로직 작성

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 SKIP_PREFLIGHT_CHECK=true
+REACT_APP_API_URL=http://localhost:5000

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "axios": "^0.21.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "react-toastify": "^7.0.4",
     "styled-components": "^5.3.0",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,24 @@
-/* eslint-disable arrow-body-style */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Switch, Route } from 'react-router-dom';
+import { useUserState } from './utils/hooks/useContext';
 import LoginPage from './components/pages/LoginPage/LoginPage';
 
 const App = () => {
-  return (
+  const { id } = useUserState();
+
+  useEffect(() => {
+    // TODO: API 서버에서 쿠키에 담긴 세션 아이디 검증
+  }, []);
+
+  const children = id ? (
     <Switch>
-      <Route path="/" exact component={LoginPage} />
+      <Route exact path="/" render={() => <h1>logged in</h1>} />
     </Switch>
+  ) : (
+    <Route path="/" component={LoginPage} />
   );
+
+  return children;
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,54 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Switch, Route } from 'react-router-dom';
-import { useUserState } from './utils/hooks/useContext';
+import axios from 'axios';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import { useDispatch, useUserState } from './utils/hooks/useContext';
 import LoginPage from './components/pages/LoginPage/LoginPage';
+import makeAPIPath from './utils/utils';
 
 const App = () => {
-  const { id } = useUserState();
+  /**
+   * FIXME: 아직 API 연동이 안 되어있어서 임시로 progress bar 넣어 둠
+   * 해결되면 지우거나 좀 더 괜찮은 모양새로 고칠 것
+   */
+  const [isLoading, setLoading] = useState<boolean>(false);
+  const state = useUserState();
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    // TODO: API 서버에서 쿠키에 담긴 세션 아이디 검증
+    setLoading(true);
+    /**
+     * FIXME: CORS 때문인지 서버가 안 떠있어서 그런 건지 콘솔에 오류가 뜸
+     * 문제 원인 파악해서 해결하고 FIXME 지워줄 것
+    */
+    axios.get(makeAPIPath('/users/me'))
+      .finally(() => { setLoading(false); })
+      .then((response) => {
+        const { id, name, avatar } = response.data;
+        dispatch({
+          type: 'login',
+          info: { id, name, avatar },
+        });
+      })
+      .catch((error) => {
+        if (error.response) {
+          dispatch({ type: 'logout' });
+        } else {
+          // TODO: toast?
+        }
+      });
   }, []);
 
-  const children = id ? (
+  const children = state.id ? (
+    // FIXME: Main Page 컴포넌트가 없어 임시로 적어 둠
     <Switch>
-      <Route exact path="/" render={() => <h1>logged in</h1>} />
+      <Route exact path="/" render={() => <h1>main page</h1>} />
     </Switch>
   ) : (
     <Route path="/" component={LoginPage} />
   );
 
-  return children;
+  return isLoading ? <LinearProgress /> : children;
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import axios from 'axios';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { useDispatch, useUserState } from './utils/hooks/useContext';
 import LoginPage from './components/pages/LoginPage/LoginPage';
@@ -34,7 +36,7 @@ const App = () => {
         if (error.response) {
           dispatch({ type: 'logout' });
         } else {
-          // TODO: toast?
+          toast.error(error.message);
         }
       });
   }, []);
@@ -48,7 +50,22 @@ const App = () => {
     <Route path="/" component={LoginPage} />
   );
 
-  return isLoading ? <LinearProgress /> : children;
+  return (
+    <>
+      <ToastContainer
+        position="top-center"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+      />
+      {isLoading ? <LinearProgress /> : children}
+    </>
+  );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,9 @@ const App = () => {
   useEffect(() => {
     setLoading(true);
     /**
-     * FIXME: CORS 때문인지 서버가 안 떠있어서 그런 건지 콘솔에 오류가 뜸
-     * 문제 원인 파악해서 해결하고 FIXME 지워줄 것
+     * FIXME: 서버가 403 주면 콘솔에 오류 뜸
+     * 서버에서 콘솔에 적는 거라 프론트에서 핸들링 불가
+     * 그러면 성공 응답을 받아야 하나?
     */
     axios.get(makeAPIPath('/users/me'))
       .finally(() => { setLoading(false); })
@@ -43,11 +44,15 @@ const App = () => {
 
   const children = state.id ? (
     // FIXME: Main Page 컴포넌트가 없어 임시로 적어 둠
+    // register page에서 세션 있는지, id 검증까지 하도록 해야 하나?
     <Switch>
       <Route exact path="/" render={() => <h1>main page</h1>} />
     </Switch>
   ) : (
-    <Route path="/" component={LoginPage} />
+    <Switch>
+      <Route exact path="/register" render={() => <h1>register page</h1>} />
+      <Route path="/" component={LoginPage} />
+    </Switch>
   );
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ const App = () => {
       })
       .catch((error) => {
         if (error.response) {
-          dispatch({ type: 'logout' });
+          dispatch({ type: 'reset' });
         } else {
           toast.error(error.message);
         }

--- a/src/components/pages/LoginPage/LoginPage.tsx
+++ b/src/components/pages/LoginPage/LoginPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import makeAPIPath from '../../../utils/utils';
 import Button from '../../atoms/Button/Button';
 import Typo from '../../atoms/Typo/Typo';
 import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
@@ -11,7 +12,7 @@ const LoginPage = () => {
         <Typo variant="h1">PONG</Typo>
       }
       button={
-        <Button href="#">로그인 / 회원가입</Button>
+        <Button href={makeAPIPath('/auth/42')}>로그인 / 회원가입</Button>
       }
     />
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
+import { ContextProvider } from './utils/hooks/useContext';
 import App from './App';
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ContextProvider>
+        <App />
+      </ContextProvider>
     </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/utils/hooks/useContext.tsx
+++ b/src/utils/hooks/useContext.tsx
@@ -1,0 +1,61 @@
+import React, {
+  createContext, useReducer, useContext, Dispatch,
+} from 'react';
+
+export interface UserStateType {
+  id: string,
+  name: string,
+  avatar: string,
+}
+
+const initialState: UserStateType = {
+  id: '',
+  name: '',
+  avatar: '',
+};
+
+type UserActionType = { type: 'login', info: UserStateType } | { type: 'logout' };
+
+const StateContext = createContext<UserStateType | undefined>(undefined);
+const DispatchContext = createContext<Dispatch<UserActionType> | undefined>(undefined);
+
+function reducer(state: UserStateType, action: UserActionType): UserStateType {
+  switch (action.type) {
+    case 'login':
+      return { ...action.info };
+    case 'logout':
+    default:
+      return { ...initialState };
+  }
+}
+
+function ContextProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return (
+    <StateContext.Provider value={state}>
+      <DispatchContext.Provider value={dispatch}>
+        {children}
+      </DispatchContext.Provider>
+    </StateContext.Provider>
+  );
+}
+
+function useUserState() {
+  const state = useContext(StateContext);
+  if (!state) {
+    throw new Error('Provider not found');
+  }
+  return (state);
+}
+
+function useDispatch() {
+  const dispatch = useContext(DispatchContext);
+  if (!dispatch) {
+    throw new Error('Provider not found');
+  }
+  return (dispatch);
+}
+
+export {
+  ContextProvider, useUserState, useDispatch,
+};

--- a/src/utils/hooks/useContext.tsx
+++ b/src/utils/hooks/useContext.tsx
@@ -14,7 +14,8 @@ const initialState: UserStateType = {
   avatar: '',
 };
 
-type UserActionType = { type: 'login', info: UserStateType } | { type: 'logout' };
+type UserActionType = { type: 'login', info: UserStateType } | { type: 'logout' }
+                    | { type: 'reset' };
 
 const StateContext = createContext<UserStateType | undefined>(undefined);
 const DispatchContext = createContext<Dispatch<UserActionType> | undefined>(undefined);
@@ -24,6 +25,7 @@ function reducer(state: UserStateType, action: UserActionType): UserStateType {
     case 'login':
       return { ...action.info };
     case 'logout':
+    case 'reset':
     default:
       return { ...initialState };
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,3 @@
+const makeAPIPath = (path: string): string => (`${process.env.REACT_APP_API_URL}${path}`);
+
+export default makeAPIPath;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4679,6 +4679,13 @@ axe-core@^4.0.2:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.1.2.tgz"
   integrity sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz"
@@ -7886,6 +7893,11 @@ follow-redirects@^1.0.0:
   version "1.13.2"
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz"
   integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+
+follow-redirects@^1.10.0:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
+  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 for-in@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5715,7 +5715,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.4:
+clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -13131,6 +13131,13 @@ react-textarea-autosize@^8.3.0:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
+
+react-toastify@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.4.tgz#7d0b743f2b96f65754264ca6eae31911a82378db"
+  integrity sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react-transition-group@^4.4.0:
   version "4.4.2"


### PR DESCRIPTION
## 기능에 대한 설명
- React의 Context API와 useReducer hook을 사용하여 App 전체의 상태 관리 로직을 작성하였습니다. 현재 state에 유저의 id가 존재하는지 확인하고, 존재하는 경우 메인 페이지, 존재하지 않으면 LoginPage 컴포넌트를 렌더링합니다(React-router 사용). 단, 메인 페이지 컴포넌트는 아직 구현되지 않았으므로 임시로 작성해 두었습니다.
- root path(``/``)로 접속할 때마다(=App 컴포넌트가 마운트 될 때마다) 세션 ID를 검증합니다. 세션이 살아있는 경우 API 서버에서 받아온 유저 정보를 state에 저장하고, 등록된 세션이 없는 경우 앱의 state를 초기화하여 로그인을 유도합니다.
- 현재 작업 단계에서 API 서버와 통신이 이루어지지 않기 때문에 코드를 임의로 작성한 부분이 몇 군데 있습니다. (App의 ``isLoading`` state+progress bar 등) 이 부분은 ``FIXME`` 처리 해두었으므로 추후 수정하겠습니다.
- 통신 에러 메시지를 보여주는 부분에서 Toast를 사용하면 좋을 것이라 판단해 react-toastify와 Material ui의 Snackbar 중 무엇을 도입할지 고민하였고, react-toastify를 도입하였습니다. UI 일관성을 고려하면 Material ui를 사용하는 것이 좋겠지만, react-toastify를 사용하면 부가적인 context 작성 및 다른 처리에 대한 고려 없이 toast를 간편하게 띄울 수 있다는 점이 큰 장점이라 보았습니다. 혹시 다른 의견이 있으시면 말씀해주세요!

## 테스트 (Optional)
``yarn start``로 실행 화면을 확인하며 작업했습니다.

## REFERENCE (Optional)
- [react-toastify](https://fkhadra.github.io/react-toastify/introduction)
- [Material ui Snackbar](https://material-ui.com/components/snackbars/)

## ISSUE
close #19 
