### PR TITLE
Feat: 2FA Digit input code 제작

### DIFF
--- a/src/components/atoms/DigitInput/DigitInput.stories.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.stories.tsx
@@ -11,15 +11,8 @@ export default {
 export const Default = () => {
   const [value, setValue] = useState('');
   const handleChange = (event: { target: { value: string; }; }) => {
-    const letter = /^[0-9\b]+$/;
-    if (event.target.value === '' || letter.test(event.target.value)) {
-      setValue(event.target.value);
-    }
+    const letter = /^[0-9]$/;
+    if (event.target.value === '' || letter.test(event.target.value)) setValue(event.target.value);
   };
-  return (
-    <DigitInput
-      onChange={handleChange}
-      value={value}
-    />
-  );
+  return (<DigitInput onChange={handleChange} value={value} />);
 };

--- a/src/components/atoms/DigitInput/DigitInput.stories.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.stories.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable arrow-body-style */
-import React from 'react';
+import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import DigitInput from './DigitInput';
 
@@ -8,4 +8,18 @@ export default {
   title: 'atoms/DigitInput',
 } as Meta;
 
-export const DigitInputStory = () => <DigitInput />;
+export const Default = () => {
+  const [value, setValue] = useState('');
+  const handleChange = (event: { target: { value: string; }; }) => {
+    const letter = /^[0-9\b]+$/;
+    if (event.target.value === '' || letter.test(event.target.value)) {
+      setValue(event.target.value);
+    }
+  };
+  return (
+    <DigitInput
+      onChange={handleChange}
+      value={value}
+    />
+  );
+};

--- a/src/components/atoms/DigitInput/DigitInput.stories.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable arrow-body-style */
 import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
 import DigitInput from './DigitInput';
@@ -10,7 +9,7 @@ export default {
 
 export const Default = () => {
   const [value, setValue] = useState('');
-  const handleChange = (event: { target: { value: string; }; }) => {
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
     const letter = /^[0-9]$/;
     if (event.target.value === '' || letter.test(event.target.value)) setValue(event.target.value);
   };

--- a/src/components/atoms/DigitInput/DigitInput.stories.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.stories.tsx
@@ -1,0 +1,11 @@
+/* eslint-disable arrow-body-style */
+import React from 'react';
+import { Meta } from '@storybook/react';
+import DigitInput from './DigitInput';
+
+export default {
+  component: DigitInput,
+  title: 'atoms/DigitInput',
+} as Meta;
+
+export const DigitInputStory = () => <DigitInput />;

--- a/src/components/atoms/DigitInput/DigitInput.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.tsx
@@ -6,31 +6,27 @@ const StyledDigitInput = withStyles({
   root: {
     width: 70,
     height: 100,
-    border: '1px solid',
+    border: '1px solid gray',
     borderRadius: '5px',
   },
 })(Input);
 
 type DigitInputProps = {
-  onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> | undefined,
+  onChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement> | undefined,
   value?: string,
 };
 
-// eslint-disable-next-line arrow-body-style
-const DigitInput = ({ onChange, value }: DigitInputProps) => {
-  return (
-    <StyledDigitInput
-      type="text"
-      inputProps={{ style: { textAlign: 'center', fontSize: 40 }, maxLength: 1 }}
-      onChange={onChange}
-      value={value}
-      disableUnderline
-    />
-  );
-};
+const DigitInput = ({ onChange, value }: DigitInputProps) => (
+  <StyledDigitInput
+    type="text"
+    inputProps={{ style: { textAlign: 'center', fontSize: 40 }, maxLength: 1 }}
+    onChange={onChange}
+    value={value}
+    disableUnderline
+  />
+);
 
 DigitInput.defaultProps = {
-  onChange: undefined,
   value: '',
 };
 

--- a/src/components/atoms/DigitInput/DigitInput.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.tsx
@@ -6,26 +6,32 @@ const StyledDigitInput = withStyles({
   root: {
     width: 75,
     height: 120,
-    '& input::-webkit-inner-spin-button, & input::-webkit-outer-spin-button': {
-      '-webkit-appearance': 'none',
-    },
-    '& input': {
-      '-moz-appearance': 'textfield',
-    },
   },
 })(TextField);
 
+type DigitInputProps = {
+  onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> | undefined,
+  value?: string,
+};
+
 // eslint-disable-next-line arrow-body-style
-const DigitInput = () => {
+const DigitInput = ({ onChange, value }: DigitInputProps) => {
   return (
     <StyledDigitInput
       variant="outlined"
-      type="number"
+      type="text"
       inputProps={{
-        style: { textAlign: 'center', fontSize: 50 }, margin: 0,
+        style: { textAlign: 'center', fontSize: 50 }, margin: 0, maxLength: 1,
       }}
+      onChange={onChange}
+      value={value}
     />
   );
+};
+
+DigitInput.defaultProps = {
+  onChange: null,
+  value: '',
 };
 
 export default DigitInput;

--- a/src/components/atoms/DigitInput/DigitInput.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.tsx
@@ -12,7 +12,7 @@ const StyledDigitInput = withStyles({
 })(Input);
 
 type DigitInputProps = {
-  onChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement> | undefined,
+  onChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>,
   value?: string,
 };
 

--- a/src/components/atoms/DigitInput/DigitInput.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
-import TextField from '@material-ui/core/TextField';
+import Input from '@material-ui/core/Input';
 import { withStyles } from '@material-ui/core/styles';
 
 const StyledDigitInput = withStyles({
   root: {
-    width: 75,
-    height: 120,
+    width: 70,
+    height: 100,
+    border: '1px solid',
+    borderRadius: '5px',
   },
-})(TextField);
+})(Input);
 
 type DigitInputProps = {
   onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> | undefined,
@@ -18,19 +20,17 @@ type DigitInputProps = {
 const DigitInput = ({ onChange, value }: DigitInputProps) => {
   return (
     <StyledDigitInput
-      variant="outlined"
       type="text"
-      inputProps={{
-        style: { textAlign: 'center', fontSize: 50 }, margin: 0, maxLength: 1,
-      }}
+      inputProps={{ style: { textAlign: 'center', fontSize: 40 }, maxLength: 1 }}
       onChange={onChange}
       value={value}
+      disableUnderline
     />
   );
 };
 
 DigitInput.defaultProps = {
-  onChange: null,
+  onChange: undefined,
   value: '',
 };
 

--- a/src/components/atoms/DigitInput/DigitInput.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import { withStyles } from '@material-ui/core/styles';
+
+const StyledDigitInput = withStyles({
+  root: {
+    width: 75,
+    height: 120,
+    '& input::-webkit-inner-spin-button, & input::-webkit-outer-spin-button': {
+      '-webkit-appearance': 'none',
+    },
+    '& input': {
+      '-moz-appearance': 'textfield',
+    },
+  },
+})(TextField);
+
+// eslint-disable-next-line arrow-body-style
+const DigitInput = () => {
+  return (
+    <StyledDigitInput
+      variant="outlined"
+      type="number"
+      inputProps={{
+        style: { textAlign: 'center', fontSize: 50 }, margin: 0,
+      }}
+    />
+  );
+};
+
+export default DigitInput;


### PR DESCRIPTION
## 기능에 대한 설명
- 2FA DigitInput verifiaction code를 제작한다.
- [Slack email verification code box 디자인](https://blog.kakaocdn.net/dn/dC0G6u/btqw2mqwH84/mhLRfgjhGHsaZBPNkjFqb1/img.png)을 참고하여 제작
- 숫자 하나만 입력가능
- **질문:** 박스의 크기와 숫자의 크기를 보시고, 조금 더 예쁘게 만들 수 있다면 피드백을 받고 수정해보도록 하겠습니다!

## 테스트 (Optional)
각각 Firefox, Chrome, Safari로 Storybook으로 랜더링, 숫자 하나만 입력 확인

## REFERENCE (Optional)
[slack email code](https://blog.kakaocdn.net/dn/dC0G6u/btqw2mqwH84/mhLRfgjhGHsaZBPNkjFqb1/img.png)
[material-ui input](https://material-ui.com/api/input/)

## ISSUE
close #35 