### PR TITLE
Feat: 2FA Page 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Switch, Route, useHistory } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import axios from 'axios';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -12,6 +12,7 @@ import LoginPage from './components/pages/LoginPage/LoginPage';
 import makeAPIPath from './utils/utils';
 import RegisterPage from './components/pages/RegisterPage/RegisterPage';
 import MainTemplate from './components/templates/MainTemplate/MainTemplate';
+import MFARegisterPage from './components/pages/MFARegisterPage/MFARegisterPage';
 import MFAPage from './components/pages/MFAPage/MFAPage';
 
 const useStyles = makeStyles({
@@ -33,7 +34,6 @@ const useStyles = makeStyles({
 });
 
 const App = () => {
-  const history = useHistory();
   const appState = useAppState();
   const appDispatch = useAppDispatch();
   const userState = useUserState();
@@ -49,9 +49,6 @@ const App = () => {
      * 이 부분은 서브젝트 요구사항과 안 맞는 듯해서 추후 고민해봐야 할 것 같습니다.
     */
     axios.get(makeAPIPath('/session'))
-      .finally(() => {
-        appDispatch({ type: 'endLoading' });
-      })
       .then(() => {
         axios.get(makeAPIPath('/users/me'))
           .then((response) => {
@@ -62,16 +59,13 @@ const App = () => {
             });
           })
           .catch((error) => {
-            if (error.response) {
-              /** FIXME: 로그아웃+2FA 활성 상태에서는 /users/me 응답이 403입니다.
-               * 이때문에 로그인 하려는 상황에서도 register로 이동하는 문제가 발생하는데,
-               * 2FA 페이지 구현할 때 새로운 API를 이용하여 고치면 될 것 같습니다.
-               */
-              history.push('/register');
-            } else {
+            if (!(error.response)) {
               toast.error(error.message);
             }
           });
+      })
+      .finally(() => {
+        appDispatch({ type: 'endLoading' });
       })
       .catch((error) => {
         if (error.response) {
@@ -93,7 +87,8 @@ const App = () => {
   ) : (
     <Switch>
       <Route exact path="/register" component={RegisterPage} />
-      <Route exact path="/register/2FA" component={MFAPage} />
+      <Route exact path="/register/2fa" component={MFARegisterPage} />
+      <Route exact path="/2fa" component={MFAPage} />
       <Route path="/" component={LoginPage} />
     </Switch>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import LoginPage from './components/pages/LoginPage/LoginPage';
 import makeAPIPath from './utils/utils';
 import RegisterPage from './components/pages/RegisterPage/RegisterPage';
 import MainTemplate from './components/templates/MainTemplate/MainTemplate';
+import MFAPage from './components/pages/MFAPage/MFAPage';
 
 const useStyles = makeStyles({
   progress: {
@@ -92,6 +93,7 @@ const App = () => {
   ) : (
     <Switch>
       <Route exact path="/register" component={RegisterPage} />
+      <Route exact path="/register/2FA" component={MFAPage} />
       <Route path="/" component={LoginPage} />
     </Switch>
   );

--- a/src/components/atoms/DigitInput/DigitInput.tsx
+++ b/src/components/atoms/DigitInput/DigitInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ForwardedRef } from 'react';
 import Input from '@material-ui/core/Input';
 import { withStyles } from '@material-ui/core/styles';
 
@@ -6,6 +6,7 @@ const StyledDigitInput = withStyles({
   root: {
     width: 70,
     height: 100,
+    margin: '5px',
     border: '1px solid gray',
     borderRadius: '5px',
   },
@@ -13,21 +14,26 @@ const StyledDigitInput = withStyles({
 
 type DigitInputProps = {
   onChange: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>,
+  name?: string,
   value?: string,
 };
 
-const DigitInput = ({ onChange, value }: DigitInputProps) => (
-  <StyledDigitInput
-    type="text"
-    inputProps={{ style: { textAlign: 'center', fontSize: 40 }, maxLength: 1 }}
-    onChange={onChange}
-    value={value}
-    disableUnderline
-  />
-);
+const DigitInput = React.forwardRef(({ onChange, name, value }: DigitInputProps,
+  ref: ForwardedRef<HTMLInputElement | HTMLTextAreaElement>) => (
+    <StyledDigitInput
+      type="text"
+      name={name}
+      inputRef={ref}
+      inputProps={{ style: { textAlign: 'center', fontSize: 40 }, maxLength: 1 }}
+      onChange={onChange}
+      value={value}
+      disableUnderline
+    />
+));
 
 DigitInput.defaultProps = {
   value: '',
+  name: '',
 };
 
 export default DigitInput;

--- a/src/components/pages/MFAPage/MFAPage.stories.tsx
+++ b/src/components/pages/MFAPage/MFAPage.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import MFAPage from './MFAPage';
+
+export default {
+  component: MFAPage,
+  title: 'pages/MFAPage',
+} as Meta;
+
+export const Login = () => (
+  <MFAPage />
+);

--- a/src/components/pages/MFAPage/MFAPage.stories.tsx
+++ b/src/components/pages/MFAPage/MFAPage.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
+import { ToastContainer } from 'react-toastify';
 import MFAPage from './MFAPage';
+import { ContextProvider } from '../../../utils/hooks/useContext';
 
 export default {
   component: MFAPage,
@@ -8,5 +10,18 @@ export default {
 } as Meta;
 
 export const Login = () => (
-  <MFAPage />
+  <ContextProvider>
+    <ToastContainer
+      position="top-center"
+      autoClose={5000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+    />
+    <MFAPage />
+  </ContextProvider>
 );

--- a/src/components/pages/MFAPage/MFAPage.tsx
+++ b/src/components/pages/MFAPage/MFAPage.tsx
@@ -1,46 +1,85 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import Button from '../../atoms/Button/Button';
-import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
-import { useAppDispatch } from '../../../utils/hooks/useContext';
+import { useAppDispatch, useUserDispatch } from '../../../utils/hooks/useContext';
 import makeAPIPath from '../../../utils/utils';
+import Button from '../../atoms/Button/Button';
+import DigitInput from '../../atoms/DigitInput/DigitInput';
+import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
+
+type digitString = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '';
+
+const usePrevious = (value: digitString[]) => {
+  const ref = useRef<digitString[]>(['', '', '', '', '', '']);
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
 
 const MFAPage = () => {
-  const [QRCode, setQRCode] = useState<Blob>();
-  const [QRImageSrc, setQRSrc] = useState<string>('');
+  const [inputs, setInputs] = useState<digitString[]>(['', '', '', '', '', '']);
+  const refs = inputs.map(() => useRef<HTMLInputElement | HTMLTextAreaElement>(null));
   const appDispatch = useAppDispatch();
+  const userDispatch = useUserDispatch();
+  const history = useHistory();
+  const prevInputs = usePrevious(inputs);
 
   useEffect(() => {
+    let idx = 0;
+    for (let i = 0; i < 6; i += 1) {
+      if (inputs[i] !== prevInputs[i]) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx !== 5 && inputs[idx] !== '') refs[idx + 1].current?.focus();
+    else if (idx === 0) refs[0].current?.focus();
+  }, [inputs]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    if (value === '' || /^[0-9]$/.test(value)) {
+      const index = Number(name);
+      const renew: digitString[] = inputs.map((input: digitString, idx): digitString => (
+        idx === index ? value as digitString : input
+      ));
+      setInputs(renew);
+    }
+  };
+
+  const Inputs = inputs.map((input, idx) => (
+    <DigitInput
+      key={`digit${String(idx)}`}
+      onChange={handleChange}
+      name={String(idx)}
+      value={input}
+      ref={refs[idx]}
+    />
+  ));
+
+  const handleClick = () => {
     appDispatch({ type: 'loading' });
-    axios.get(makeAPIPath('/auth/otp/qrcode'))
+    axios.post(makeAPIPath('/auth/otp'), { token: inputs.join('') })
       .finally(() => {
         appDispatch({ type: 'endLoading' });
       })
       .then((response) => {
-        setQRCode(response.data);
+        const { id, name, avatar } = response.data;
+        userDispatch({ type: 'login', info: { id, name, avatar } });
+        history.push('/');
       })
       .catch((error) => {
-        toast.error(error.message);
+        if (error.response) toast.error('인증 번호가 잘못되었습니다.');
+        else toast.error(error.message);
       });
-  }, []);
-
-  useEffect(() => {
-    if (!QRCode) {
-      toast.error('QR코드를 받아오지 못했습니다.');
-      return;
-    }
-    const fileReader = new FileReader();
-    fileReader.onload = (event) => {
-      if (event.target) setQRSrc(String(event.target.result));
-    };
-    fileReader.readAsDataURL(QRCode);
-  }, [QRCode]);
+  };
 
   return (
     <LoginTemplate
-      input={<img alt="QR Code" src={QRImageSrc} />}
-      button={<Button>2FA 등록</Button>}
+      input={Inputs}
+      button={<Button onClick={handleClick}>2FA 인증</Button>}
     />
   );
 };

--- a/src/components/pages/MFAPage/MFAPage.tsx
+++ b/src/components/pages/MFAPage/MFAPage.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from '@material-ui/core/styles';
 import axios from 'axios';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -6,7 +7,17 @@ import { useAppDispatch, useUserDispatch } from '../../../utils/hooks/useContext
 import makeAPIPath from '../../../utils/utils';
 import Button from '../../atoms/Button/Button';
 import DigitInput from '../../atoms/DigitInput/DigitInput';
+import Typo from '../../atoms/Typo/Typo';
 import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
+
+const useStyles = makeStyles({
+  inputs: {
+    margin: '1em',
+  },
+  typo: {
+    color: 'gray',
+  },
+});
 
 type digitString = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '';
 
@@ -25,6 +36,7 @@ const MFAPage = () => {
   const userDispatch = useUserDispatch();
   const history = useHistory();
   const prevInputs = usePrevious(inputs);
+  const classes = useStyles();
 
   useEffect(() => {
     let idx = 0;
@@ -78,7 +90,12 @@ const MFAPage = () => {
 
   return (
     <LoginTemplate
-      input={Inputs}
+      input={(
+        <>
+          <Typo className={classes.typo}>인증 번호를 정상 입력하였는데도 로그인할 수 없는 경우 담당자에게 문의해주세요.</Typo>
+          <main className={classes.inputs}>{Inputs}</main>
+        </>
+      )}
       button={<Button onClick={handleClick}>2FA 인증</Button>}
     />
   );

--- a/src/components/pages/MFAPage/MFAPage.tsx
+++ b/src/components/pages/MFAPage/MFAPage.tsx
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import Button from '../../atoms/Button/Button';
+import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
+import { useAppDispatch } from '../../../utils/hooks/useContext';
+import makeAPIPath from '../../../utils/utils';
+
+const MFAPage = () => {
+  const [QRCode, setQRCode] = useState<Blob>();
+  const [QRImageSrc, setQRSrc] = useState<string>('');
+  const appDispatch = useAppDispatch();
+
+  useEffect(() => {
+    appDispatch({ type: 'loading' });
+    axios.get(makeAPIPath('/auth/otp/qrcode'))
+      .finally(() => {
+        appDispatch({ type: 'endLoading' });
+      })
+      .then((response) => {
+        setQRCode(response.data);
+      })
+      .catch((error) => {
+        toast.error(error.message);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!QRCode) {
+      toast.error('QR코드를 받아오지 못했습니다.');
+      return;
+    }
+    const fileReader = new FileReader();
+    fileReader.onload = (event) => {
+      if (event.target) setQRSrc(String(event.target.result));
+    };
+    fileReader.readAsDataURL(QRCode);
+  }, [QRCode]);
+
+  return (
+    <LoginTemplate
+      input={<img alt="QR Code" src={QRImageSrc} />}
+      button={<Button>2FA 등록</Button>}
+    />
+  );
+};
+
+export default MFAPage;

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.stories.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { Meta } from '@storybook/react';
 import { ToastContainer } from 'react-toastify';
 import MFARegisterPage from './MFARegisterPage';
@@ -10,18 +11,20 @@ export default {
 } as Meta;
 
 export const Login = () => (
-  <ContextProvider>
-    <ToastContainer
-      position="top-center"
-      autoClose={5000}
-      hideProgressBar={false}
-      newestOnTop={false}
-      closeOnClick
-      rtl={false}
-      pauseOnFocusLoss
-      draggable
-      pauseOnHover
-    />
-    <MFARegisterPage />
-  </ContextProvider>
+  <BrowserRouter>
+    <ContextProvider>
+      <ToastContainer
+        position="top-center"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+      />
+      <MFARegisterPage />
+    </ContextProvider>
+  </BrowserRouter>
 );

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.stories.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
+import { ToastContainer } from 'react-toastify';
 import MFARegisterPage from './MFARegisterPage';
+import { ContextProvider } from '../../../utils/hooks/useContext';
 
 export default {
   component: MFARegisterPage,
@@ -8,5 +10,18 @@ export default {
 } as Meta;
 
 export const Login = () => (
-  <MFARegisterPage />
+  <ContextProvider>
+    <ToastContainer
+      position="top-center"
+      autoClose={5000}
+      hideProgressBar={false}
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+    />
+    <MFARegisterPage />
+  </ContextProvider>
 );

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.stories.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import MFARegisterPage from './MFARegisterPage';
+
+export default {
+  component: MFARegisterPage,
+  title: 'pages/MFARegisterPage',
+} as Meta;
+
+export const Login = () => (
+  <MFARegisterPage />
+);

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
@@ -1,0 +1,71 @@
+// import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
+import Button from '../../atoms/Button/Button';
+import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
+import { useAppDispatch } from '../../../utils/hooks/useContext';
+import makeAPIPath from '../../../utils/utils';
+
+const MFARegisterPage = () => {
+  const [QRCode, setQRCode] = useState<Blob | string>('');
+  const [QRImageSrc, setQRSrc] = useState<string>('');
+  const appDispatch = useAppDispatch();
+
+  useEffect(() => {
+    appDispatch({ type: 'loading' });
+
+    fetch(makeAPIPath('/auth/otp/qrcode'), { credentials: 'include' })
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      .then(processChunkedResponse)
+      .then((result) => {
+        setQRCode(result);
+      })
+      .catch((error) => {
+        toast.error(error.message);
+      });
+
+    function processChunkedResponse(response: any) {
+      let text = '';
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      function readChunk() {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        return reader.read().then(appendChunks);
+      }
+
+      function appendChunks(result: any) {
+        const chunk = decoder.decode(result.value || new Uint8Array(), { stream: !result.done });
+        text += chunk;
+        if (result.done) {
+          return text;
+        }
+        return readChunk();
+      }
+      return readChunk();
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.log(QRCode);
+    if (!QRCode) {
+      toast.error('QR코드를 받아오지 못했습니다.');
+      return;
+    }
+    const fileReader = new FileReader();
+    fileReader.onload = (event) => {
+      if (event.target) setQRSrc(String(event.target.result));
+    };
+    fileReader.readAsDataURL(QRCode as Blob);
+  }, [QRCode]);
+
+  return (
+    <LoginTemplate
+      input={<img alt="QR Code" src={QRImageSrc} />}
+      button={<Button>2FA 등록</Button>}
+    />
+  );
+};
+
+export default MFARegisterPage;

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
@@ -2,13 +2,25 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '../../atoms/Button/Button';
+import Dialog from '../../molecules/Dialog/Dialog';
 import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
 import { useAppDispatch } from '../../../utils/hooks/useContext';
 import makeAPIPath from '../../../utils/utils';
+import Typo from '../../atoms/Typo/Typo';
+
+const useStyles = makeStyles({
+  image: {
+    margin: '1em',
+    display: 'block',
+  },
+});
 
 const MFARegisterPage = () => {
   const [QRImageSrc, setQRSrc] = useState<string>('');
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const classes = useStyles();
   const appDispatch = useAppDispatch();
   const history = useHistory();
 
@@ -25,15 +37,35 @@ const MFARegisterPage = () => {
   }, []);
 
   const handleClick = () => {
-    // TODO: QR 정상 등록했는지 아닌지 확인해줘야 하지 않나?
-    history.push('/');
+    setDialogOpen(true);
   };
 
+  const buttons = (
+    <>
+      <Button variant="text" onClick={() => { setDialogOpen(false); }}>아니오, 아직 등록하지 않았습니다</Button>
+      <Button onClick={() => { history.push('/'); }}>네, 등록을 완료했습니다</Button>
+    </>
+  );
+
   return (
-    <LoginTemplate
-      input={<img alt="QR Code" src={QRImageSrc} />}
-      button={<Button onClick={handleClick}>2FA 등록</Button>}
-    />
+    <>
+      <Dialog
+        isOpen={isDialogOpen}
+        title="QR 코드 등록 확인"
+        content="Google OTP 앱에 QR 코드를 정상적으로 등록하셨나요? QR 코드를 등록하지 않고 해당 페이지를 벗어나면 2FA 인증이 불가능합니다. 확인하셨다면 아래 버튼을 클릭해주세요."
+        buttons={buttons}
+        handleClose={() => { setDialogOpen(false); }}
+      />
+      <LoginTemplate
+        input={(
+          <>
+            <figcaption><Typo>Google OTP 어플리케이션을 설치하고 아래 QR 코드를 스캔해주세요.</Typo></figcaption>
+            <figure><img className={classes.image} alt="QR Code" src={QRImageSrc} /></figure>
+          </>
+        )}
+        button={<Button onClick={handleClick}>2FA 등록</Button>}
+      />
+    </>
   );
 };
 

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
@@ -1,5 +1,6 @@
 // import axios from 'axios';
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import Button from '../../atoms/Button/Button';
 import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
@@ -7,63 +8,31 @@ import { useAppDispatch } from '../../../utils/hooks/useContext';
 import makeAPIPath from '../../../utils/utils';
 
 const MFARegisterPage = () => {
-  const [QRCode, setQRCode] = useState<Blob | string>('');
   const [QRImageSrc, setQRSrc] = useState<string>('');
   const appDispatch = useAppDispatch();
+  const history = useHistory();
 
   useEffect(() => {
     appDispatch({ type: 'loading' });
 
     fetch(makeAPIPath('/auth/otp/qrcode'), { credentials: 'include' })
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      .then(processChunkedResponse)
-      .then((result) => {
-        setQRCode(result);
-      })
+      .finally(() => { appDispatch({ type: 'endLoading' }); })
+      .then((response) => response.blob())
+      .then((blob) => setQRSrc(URL.createObjectURL(blob)))
       .catch((error) => {
         toast.error(error.message);
       });
-
-    function processChunkedResponse(response: any) {
-      let text = '';
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-
-      function readChunk() {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        return reader.read().then(appendChunks);
-      }
-
-      function appendChunks(result: any) {
-        const chunk = decoder.decode(result.value || new Uint8Array(), { stream: !result.done });
-        text += chunk;
-        if (result.done) {
-          return text;
-        }
-        return readChunk();
-      }
-      return readChunk();
-    }
   }, []);
 
-  useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(QRCode);
-    if (!QRCode) {
-      toast.error('QR코드를 받아오지 못했습니다.');
-      return;
-    }
-    const fileReader = new FileReader();
-    fileReader.onload = (event) => {
-      if (event.target) setQRSrc(String(event.target.result));
-    };
-    fileReader.readAsDataURL(QRCode as Blob);
-  }, [QRCode]);
+  const handleClick = () => {
+    // TODO: QR 정상 등록했는지 아닌지 확인해줘야 하지 않나?
+    history.push('/');
+  };
 
   return (
     <LoginTemplate
       input={<img alt="QR Code" src={QRImageSrc} />}
-      button={<Button>2FA 등록</Button>}
+      button={<Button onClick={handleClick}>2FA 등록</Button>}
     />
   );
 };

--- a/src/components/pages/RegisterPage/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage/RegisterPage.tsx
@@ -107,11 +107,7 @@ const RegisterPage = () => {
       })
       .then(() => {
         if (is2FAEnabled) {
-          /**
-           * FIXME: 2FA 페이지가 구현되고 나면 2FA 페이지로 이동시켜야 합니다.
-           * history.push('/register/2FA') 같은 식으로 하면 될 것 같습니다.
-           */
-          history.push('/');
+          history.push('/register/2fa');
         } else {
           history.push('/');
         }


### PR DESCRIPTION
## 기능에 대한 설명
피어 프로그래밍으로 구현하였습니다.
- 2FA를 등록할 수 있는 페이지(`MFARegisterPage`), 2FA 인증을 진행할 수 있는 페이지(`MFAPage`) 컴포넌트를 작성하였습니다. 변수 이름 첫글자에 숫자를 사용할 수 없기 때문에 2FA 대신 MFA라는 명칭을 사용하였습니다.
- 2FA는 google authenticator(=google OTP) 모바일 어플리케이션을 이용하여 진행합니다. 회원가입 시 2FA를 활성화하면 QR코드 등록 화면으로 이동하며, QR코드를 등록한 후 로그인을 시도하면 2FA 인증 화면에서 6자리 OTP 코드를 입력받도록 되어 있습니다.
<br>

- ~**개선 요구사항**: 지금은 `MFARegisterPage`에서 2FA 등록 버튼을 누르면 사용자가 QR코드를 스캔하였는지 여부를 확인하지 않고 2FA 등록을 종료합니다. 그런데 **사용자가 QR코드를 스캔하지 않고 2FA 등록 버튼을 누를 가능성**이 있기 때문에 이 부분에 개선이 필요할 것 같습니다. QR코드 등록이 정상적으로 완료되었는지 확인하는 API 구현을 백엔드 팀에 요청하고, 2FA 등록 시 해당 API와 요청-응답으로 확인하는 방법으로 개선할 수 있을 듯합니다.  
  추가 API 구현 없이 프론트엔드 단에서 해결할 방법(App.tsx의 useEffect 응답 결과로 판단하여 history 조작)도 고민해 보았으나, history 관련 로직이 꼬여서 해당 로직을 백엔드로 옮긴 상황이기 때문에 프론트엔드에 비슷한 로직을 도입하면 다시 의도치 않은 동작을 하게 될 것 같습니다. 이렇게 구현하는 것이 최선이 아닐까 싶은데... 의견 부탁드립니다!~
**→ 반영하여 개선 완료**

## 테스트 (Optional)
- Storybook 렌더링 확인
- docker-compose로 API 서버와 연동하여 회원가입+2FA 활성화, 로그인 시 2FA 인증 진행 테스트

## REFERENCE (Optional)
- [How to Fetch and Display an Image from an express backend server to a React js frontend?](https://stackoverflow.com/questions/57829529/how-to-fetch-and-display-an-image-from-an-express-backend-server-to-a-react-js-f)

## ISSUE
close #36 