### PR TITLE
Feat: Dialog component 제작

### DIFF
--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -11,6 +11,7 @@ const StyledButton = withStyles({
 })(MaterialButton);
 
 type ButtonProps = {
+  variant?: 'contained' | 'outlined' | 'text',
   onClick?: MouseEventHandler<HTMLButtonElement>,
   type?: 'button' | 'submit' | 'reset',
   children: React.ReactNode,
@@ -19,11 +20,11 @@ type ButtonProps = {
 };
 
 const Button = ({
-  onClick, type, children, href, disabled,
+  variant, onClick, type, children, href, disabled,
 }: ButtonProps) => {
   return (
     <StyledButton
-      variant="contained"
+      variant={variant}
       type={type}
       color="primary"
       onClick={onClick}
@@ -36,6 +37,7 @@ const Button = ({
 };
 
 Button.defaultProps = {
+  variant: 'contained',
   onClick: null,
   type: 'button',
   href: undefined,

--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -10,8 +10,7 @@ const StyledInput = withStyles({
 })(TextField);
 
 export type InputProps = {
-  // eslint-disable-next-line no-unused-vars
-  onChange: (event: React.ChangeEvent) => void,
+  onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>,
   value?: string,
   error?: boolean,
   type?: 'number' | 'text' | 'password',

--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable no-console */
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react';
+import Dialog from './Dialog';
+import Button from '../../atoms/Button/Button';
+import Input from '../../atoms/Input/Input';
+import Typo from '../../atoms/Typo/Typo';
+
+export default {
+  component: Dialog,
+  title: 'molecules/Dialog',
+} as Meta;
+
+export const Default = () => {
+  const [isOpen, setOpen] = useState(false);
+  const buttons = <Button variant="text" onClick={() => { setOpen(false); }}>CLOSE</Button>;
+
+  return (
+    <>
+      <Button onClick={() => { setOpen(true); }}>OPEN DIALOG</Button>
+      <Dialog
+        title="SAMPLE DIALOG"
+        content="This is sample dialog message"
+        isOpen={isOpen}
+        buttons={buttons}
+        handleClose={() => { setOpen(false); }}
+      />
+    </>
+  );
+};
+
+export const WithForm = () => {
+  const [isOpen, setOpen] = useState(false);
+  const [value, setValue] = useState<string>('');
+
+  const handleClose = () => {
+    setValue('');
+    setOpen(false);
+  };
+
+  const handleSubmit = () => {
+    if (value.length > 0 && value.length < 11) {
+      console.log(`처리되었습니다. 입력: ${value}`);
+      handleClose();
+    } else console.log('1~10글자 사이로 입력하세요.');
+  };
+
+  const buttons = (
+    <>
+      <Button variant="text" onClick={handleSubmit}>SUBMIT</Button>
+      <Button variant="text" onClick={handleClose}>CLOSE</Button>
+    </>
+  );
+
+  const form = (
+    <form>
+      <Typo>1~10글자 입력하면 제출 후 콘솔에서 결과를 확인할 수 있습니다.</Typo>
+      <Input
+        value={value}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => { setValue(e.target.value); }}
+      />
+    </form>
+  );
+
+  return (
+    <>
+      <Button onClick={() => { setOpen(true); }}>OPEN DIALOG</Button>
+      <Dialog
+        title="SAMPLE DIALOG"
+        content={form}
+        isOpen={isOpen}
+        buttons={buttons}
+        handleClose={handleClose}
+      />
+    </>
+  );
+};

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import MaterialDialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+
+type DialogProps = {
+  title?: React.ReactNode,
+  content: React.ReactNode,
+  buttons?: React.ReactNode,
+  isOpen: boolean,
+  // eslint-disable-next-line no-unused-vars
+  handleClose: (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => void,
+};
+
+const Dialog = ({
+  title, content, buttons, isOpen, handleClose,
+  // eslint-disable-next-line arrow-body-style
+}: DialogProps) => {
+  return (
+    <MaterialDialog
+      open={isOpen}
+      onClose={handleClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      {title && <DialogTitle>{title}</DialogTitle>}
+      <DialogContent>{content}</DialogContent>
+      {buttons && <DialogActions>{buttons}</DialogActions>}
+    </MaterialDialog>
+  );
+};
+
+Dialog.defaultProps = {
+  title: null,
+  buttons: null,
+};
+
+export default Dialog;

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -7,7 +7,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 type DialogProps = {
   title?: React.ReactNode,
   content: React.ReactNode,
-  buttons?: React.ReactNode,
+  buttons: React.ReactNode,
   isOpen: boolean,
   // eslint-disable-next-line no-unused-vars
   handleClose: (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => void,
@@ -26,14 +26,13 @@ const Dialog = ({
     >
       {title && <DialogTitle>{title}</DialogTitle>}
       <DialogContent>{content}</DialogContent>
-      {buttons && <DialogActions>{buttons}</DialogActions>}
+      <DialogActions>{buttons}</DialogActions>
     </MaterialDialog>
   );
 };
 
 Dialog.defaultProps = {
   title: null,
-  buttons: null,
 };
 
 export default Dialog;


### PR DESCRIPTION
## 기능에 대한 설명
- 범용으로 사용될 수 있는 Dialog component를 제작했습니다.
### 사용 예시
- 2FA 등록 화면에서 QR코드 등록 확인 용도로 사용
- 프로필 수정, 2FA 여부 변경 등의 기능에 Dialog를 사용하면 새 페이지를 만들지 않고도 구현 가능

## 테스트 (Optional)

Storybook으로 렌더링 확인

## REFERENCE (Optional)
- [Material UI Dialogs](https://material-ui.com/components/dialogs/)

## ISSUE
close #41