### PR TITLE
Feat: ProfileCard component 제작

### DIFF
--- a/src/components/atoms/Avatar/Avatar.tsx
+++ b/src/components/atoms/Avatar/Avatar.tsx
@@ -15,8 +15,8 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
     height: theme.spacing(5),
   },
   large: {
-    width: theme.spacing(7),
-    height: theme.spacing(7),
+    width: theme.spacing(9),
+    height: theme.spacing(9),
   },
 }));
 

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -11,6 +11,7 @@ const StyledButton = withStyles({
 })(MaterialButton);
 
 type ButtonProps = {
+  className?: string,
   variant?: 'contained' | 'outlined' | 'text',
   onClick?: MouseEventHandler<HTMLButtonElement>,
   type?: 'button' | 'submit' | 'reset',
@@ -20,10 +21,11 @@ type ButtonProps = {
 };
 
 const Button = ({
-  variant, onClick, type, children, href, disabled,
+  className, variant, onClick, type, children, href, disabled,
 }: ButtonProps) => {
   return (
     <StyledButton
+      className={className}
       variant={variant}
       type={type}
       color="primary"
@@ -37,6 +39,7 @@ const Button = ({
 };
 
 Button.defaultProps = {
+  className: null,
   variant: 'contained',
   onClick: null,
   type: 'button',

--- a/src/components/molecules/UserProfile/UserProfile.stories.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.stories.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Meta, Story } from '@storybook/react';
+import { UserInfoType } from '../../../types/User';
+import UserProfile from './UserProfile';
+
+export default {
+  title: 'molecules/UserProfile',
+  component: UserProfile,
+} as Meta;
+
+export const Default: Story<UserInfoType> = ({ status }: UserInfoType) => {
+  const userInfo: UserInfoType = {
+    id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+    name: 'USERNAME',
+    avatar: '',
+    status,
+  };
+
+  return <UserProfile userInfo={userInfo} />;
+};
+
+Default.args = {
+  status: 'ONLINE',
+};

--- a/src/components/molecules/UserProfile/UserProfile.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import { UserInfoType, UserStatusType } from '../../../types/User';
+import Avatar from '../../atoms/Avatar/Avatar';
+import Typo from '../../atoms/Typo/Typo';
+
+type styleProps = { status: UserStatusType };
+
+const useStyles = makeStyles({
+  status: {
+    color: (props: styleProps) => {
+      switch (props.status) {
+        case 'ONLINE':
+          return 'lightgreen';
+        case 'OFFLINE':
+          return 'gray';
+        case 'IN_GAME':
+          return 'blue';
+        default:
+          return 'black';
+      }
+    },
+  },
+});
+
+export type UserProfileProps = {
+  userInfo: UserInfoType,
+};
+
+// eslint-disable-next-line arrow-body-style
+const UserProfile = ({ userInfo }: UserProfileProps) => {
+  const { name, avatar, status } = userInfo;
+  const classes = useStyles({ status });
+
+  const makeStatusString = (): string => {
+    switch (status) {
+      case 'ONLINE':
+      case 'OFFLINE':
+        return status;
+      case 'IN_GAME':
+        return '게임 중';
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <Grid item container justifyContent="space-around" alignItems="center" xs={5}>
+      <Grid container item xs={6} justifyContent="center">
+        <Avatar size="large" alt={name} src={avatar} />
+      </Grid>
+      <Grid item xs={6}>
+        <Typo variant="h5">{name}</Typo>
+        <Typo className={classes.status}>{makeStatusString()}</Typo>
+        <Typo
+          variant="body2"
+          // FIXME: game 관련 정보가 fix되면 수정해야 합니다.
+        >
+          n점 / n승 n패 (임시)
+        </Typo>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default UserProfile;

--- a/src/components/organisms/ProfileCard/ProfileCard.stories.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.stories.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Meta } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
-import { ContextProvider } from '../../../utils/hooks/useContext';
+import { ContextProvider, useUserDispatch } from '../../../utils/hooks/useContext';
 import ProfileCard from './ProfileCard';
 import { UserInfoType } from '../../../types/User';
 import MainTemplate from '../../templates/MainTemplate/MainTemplate';
@@ -11,13 +11,13 @@ export default {
   component: ProfileCard,
 } as Meta;
 
-export const Default = () => {
+export const OthersProfile = () => {
   const handleClick = () => {};
   const userInfo: UserInfoType = {
     id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
     name: 'USERNAME',
     avatar: '',
-    status: 'ONLINE',
+    status: 'OFFLINE',
   };
 
   return (
@@ -34,13 +34,52 @@ export const Default = () => {
   );
 };
 
-export const WithTemplate = () => {
+const ProfileCardWithContext = () => {
+  const handleClick = () => {};
+  const userDispatch = useUserDispatch();
+  const userInfo: UserInfoType = {
+    id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+    name: 'MYNAME',
+    avatar: '',
+    status: 'ONLINE',
+  };
+
+  useEffect(() => {
+    userDispatch({
+      type: 'login',
+      info: {
+        id: userInfo.id,
+        name: userInfo.name,
+        avatar: userInfo.avatar,
+      },
+    });
+  }, []);
+
+  return (
+    <ProfileCard
+      userInfo={userInfo}
+      onProfileEdit={handleClick}
+      onFriendAdd={handleClick}
+      onUserBlock={handleClick}
+      onDMClick={handleClick}
+      onMatchInvite={handleClick}
+    />
+  );
+};
+
+export const MyProfile = () => (
+  <ContextProvider>
+    <ProfileCardWithContext />
+  </ContextProvider>
+);
+
+export const OthersProfileWithTemplate = () => {
   const handleClick = () => {};
   const userInfo: UserInfoType = {
     id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
     name: 'USERNAME',
     avatar: '',
-    status: 'ONLINE',
+    status: 'IN_GAME',
   };
 
   return (
@@ -63,3 +102,14 @@ export const WithTemplate = () => {
     </BrowserRouter>
   );
 };
+
+export const MyProfileWithTemplate = () => (
+  <BrowserRouter>
+    <ContextProvider>
+      <MainTemplate
+        main={<ProfileCardWithContext />}
+        chat={<h1>chat</h1>}
+      />
+    </ContextProvider>
+  </BrowserRouter>
+);

--- a/src/components/organisms/ProfileCard/ProfileCard.stories.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.stories.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { ContextProvider } from '../../../utils/hooks/useContext';
+import ProfileCard from './ProfileCard';
+import { UserInfoType } from '../../../types/User';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+
+export default {
+  title: 'organisms/ProfileCard',
+  component: ProfileCard,
+} as Meta;
+
+export const Default = () => {
+  const handleClick = () => {};
+  const userInfo: UserInfoType = {
+    id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+    name: 'USERNAME',
+    avatar: '',
+    status: 'ONLINE',
+  };
+
+  return (
+    <ContextProvider>
+      <ProfileCard
+        userInfo={userInfo}
+        onProfileEdit={handleClick}
+        onFriendAdd={handleClick}
+        onUserBlock={handleClick}
+        onDMClick={handleClick}
+        onMatchInvite={handleClick}
+      />
+    </ContextProvider>
+  );
+};
+
+export const WithTemplate = () => {
+  const handleClick = () => {};
+  const userInfo: UserInfoType = {
+    id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+    name: 'USERNAME',
+    avatar: '',
+    status: 'ONLINE',
+  };
+
+  return (
+    <BrowserRouter>
+      <ContextProvider>
+        <MainTemplate
+          main={(
+            <ProfileCard
+              onProfileEdit={handleClick}
+              onFriendAdd={handleClick}
+              onUserBlock={handleClick}
+              onDMClick={handleClick}
+              onMatchInvite={handleClick}
+              userInfo={userInfo}
+            />
+        )}
+          chat={<h1>chat</h1>}
+        />
+      </ContextProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/components/organisms/ProfileCard/ProfileCard.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+import { useUserState } from '../../../utils/hooks/useContext';
+import { UserInfoType } from '../../../types/User';
+import Button from '../../atoms/Button/Button';
+import UserProfile from '../../molecules/UserProfile/UserProfile';
+
+const useStyles = makeStyles({
+  root: {
+    padding: '0.5em',
+    width: '100%',
+    height: '100px',
+  },
+  button: {
+    width: '6.5em',
+  },
+});
+
+type ProfileCardProps = {
+  userInfo: UserInfoType,
+  onProfileEdit: React.MouseEventHandler,
+  onFriendAdd: React.MouseEventHandler,
+  onUserBlock: React.MouseEventHandler,
+  onDMClick: React.MouseEventHandler,
+  onMatchInvite: React.MouseEventHandler,
+};
+
+type ButtonObjType = {
+  text: string,
+  onClick: React.MouseEventHandler,
+};
+
+const ProfileCard = ({
+  userInfo, onProfileEdit, onFriendAdd, onUserBlock, onDMClick, onMatchInvite,
+}: ProfileCardProps) => {
+  const me = useUserState();
+  const classes = useStyles({ status: userInfo.status });
+
+  const myButtons: ButtonObjType[] = [
+    {
+      text: '정보 수정',
+      onClick: onProfileEdit,
+    },
+  ];
+
+  const otherButtons: ButtonObjType[] = [
+    {
+      text: '친구 추가',
+      onClick: onFriendAdd,
+    },
+    {
+      text: '유저 차단',
+      onClick: onUserBlock,
+    },
+    {
+      text: 'DM',
+      onClick: onDMClick,
+    },
+    {
+      text: '매치 초대',
+      onClick: onMatchInvite,
+    },
+  ];
+
+  const buttonArray = me.id === userInfo.id ? myButtons : otherButtons;
+
+  const Buttons = buttonArray.map((button) => (
+    <Grid item key={button.text}>
+      <Button
+        className={classes.button}
+        variant="outlined"
+        onClick={button.onClick}
+        key={button.text}
+      >
+        {button.text}
+      </Button>
+    </Grid>
+  ));
+
+  return (
+    <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
+      <UserProfile userInfo={userInfo} />
+      <Grid item container justifyContent="center" alignItems="center" xs={7}>
+        {Buttons}
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ProfileCard;

--- a/src/components/organisms/ProfileCard/ProfileCard.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.tsx
@@ -81,7 +81,7 @@ const ProfileCard = ({
   return (
     <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
       <UserProfile userInfo={userInfo} />
-      <Grid item container justifyContent="center" alignItems="center" xs={7}>
+      <Grid item container justifyContent="flex-end" alignItems="center" xs={7}>
         {Buttons}
       </Grid>
     </Grid>

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,8 @@
+export type UserStatusType = 'ONLINE' | 'OFFLINE' | 'IN_GAME';
+
+export type UserInfoType = {
+  id: string,
+  name: string,
+  avatar: string,
+  status: UserStatusType,
+};


### PR DESCRIPTION
## 기능에 대한 설명
- `UserProfile` component(molecules)를 작성했습니다. 유저의 avatar, name, status, 전적을 표시해줍니다. 원래는 ProfileCard 컴포넌트 내부에 작성하려 했던 내용이나, (1) 친구 목록이나 차단 목록에서 본 컴포넌트를 재사용할 수 있지 않을까 하여 (2) ProfileCard component 내부에 너무 많은 내용이 들어가는 것이 아닌지 고민이 되어 molecules 수준의 컴포넌트로 분리해보았습니다.
- `ProfileCard` component(organisms)를 작성했습니다. Page 단위에서 API로부터 얻은 userInfo 객체를 props로 내려보내주면 context를 통해 본인 여부를 판단하고, 본인 프로필의 경우 정보 수정 버튼, 타인 프로필의 경우 친구 추가/유저 차단/DM/매치 초대 버튼을 보여주게 됩니다. 본 컴포넌트가 자체 status를 가지지는 않으므로 story는 임의의 userInfo 객체를 제공하는 식으로 작성하였습니다.

## 테스트 (Optional)

- Storybook으로 렌더링 확인

## REFERENCE (Optional)
- [Material UI Grid](https://material-ui.com/components/grid)

## ISSUE

close #22