### PR TITLE
Feat: 회원가입 완료 시 안내 Dialog 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import axios from 'axios';
+// eslint-disable-next-line camelcase
+import { unstable_createMuiStrictModeTheme } from '@material-ui/core';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import {
   useAppDispatch, useAppState, useUserDispatch, useUserState,
@@ -34,6 +36,7 @@ const useStyles = makeStyles({
 });
 
 const App = () => {
+  const theme = unstable_createMuiStrictModeTheme();
   const appState = useAppState();
   const appDispatch = useAppDispatch();
   const userState = useUserState();
@@ -94,7 +97,7 @@ const App = () => {
   );
 
   return (
-    <>
+    <ThemeProvider theme={theme}>
       {appState.isLoading
         && (
         <div className={classes.block}>
@@ -117,7 +120,7 @@ const App = () => {
         pauseOnHover
       />
       {children}
-    </>
+    </ThemeProvider>
   );
 };
 

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
@@ -19,7 +19,8 @@ const useStyles = makeStyles({
 
 const MFARegisterPage = () => {
   const [QRImageSrc, setQRSrc] = useState<string>('');
-  const [isDialogOpen, setDialogOpen] = useState(false);
+  const [isConfirmOpen, setConfirmOpen] = useState<boolean>(false);
+  const [isRegisterOpen, setRegisterOpen] = useState<boolean>(false);
   const classes = useStyles();
   const appDispatch = useAppDispatch();
   const history = useHistory();
@@ -37,24 +38,37 @@ const MFARegisterPage = () => {
   }, []);
 
   const handleClick = () => {
-    setDialogOpen(true);
+    setConfirmOpen(true);
   };
 
   const buttons = (
     <>
-      <Button variant="text" onClick={() => { setDialogOpen(false); }}>아니오, 아직 등록하지 않았습니다</Button>
-      <Button onClick={() => { history.push('/'); }}>네, 등록을 완료했습니다</Button>
+      <Button variant="text" onClick={() => { setConfirmOpen(false); }}>아니오, 아직 등록하지 않았습니다</Button>
+      <Button onClick={() => {
+        setConfirmOpen(false);
+        setRegisterOpen(true);
+      }}
+      >
+        네, 등록을 완료했습니다
+      </Button>
     </>
   );
 
   return (
     <>
       <Dialog
-        isOpen={isDialogOpen}
+        isOpen={isConfirmOpen}
         title="QR 코드 등록 확인"
         content="Google OTP 앱에 QR 코드를 정상적으로 등록하셨나요? QR 코드를 등록하지 않고 해당 페이지를 벗어나면 2FA 인증이 불가능합니다. 확인하셨다면 아래 버튼을 클릭해주세요."
         buttons={buttons}
-        handleClose={() => { setDialogOpen(false); }}
+        handleClose={() => { setConfirmOpen(false); }}
+      />
+      <Dialog
+        isOpen={isRegisterOpen}
+        title="회원가입 완료"
+        content="회원가입이 완료되어 로그인 화면으로 돌아갑니다. 서비스를 이용하시려면 로그인 해주세요."
+        buttons={<Button variant="text" onClick={() => { history.push('/'); }}>확인</Button>}
+        handleClose={() => { history.push('/'); }}
       />
       <LoginTemplate
         input={(

--- a/src/components/pages/RegisterPage/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage/RegisterPage.tsx
@@ -13,6 +13,7 @@ import Typo from '../../atoms/Typo/Typo';
 import Switch from '../../atoms/Switch/Switch';
 import Button from '../../atoms/Button/Button';
 import Avatar from '../../atoms/Avatar/Avatar';
+import Dialog from '../../molecules/Dialog/Dialog';
 
 const useStyles = makeStyles({
   root: {
@@ -33,6 +34,7 @@ const RegisterPage = () => {
   const [isValidName, setNameValid] = useState<boolean>(false);
   const [isNameChecked, setNameChecked] = useState<boolean>(false);
   const [is2FAEnabled, set2FA] = useState<boolean>(false);
+  const [isRegisterOpen, setRegisterOpen] = useState<boolean>(false);
   const [filename, setFilename] = useState<string | null>(null);
   const [imageFile, setImageFile] = useState<string | Blob>('');
   const [previewSrc, setPreviewSrc] = useState<string>(makeAPIPath('/files/avatar/default.png'));
@@ -109,7 +111,7 @@ const RegisterPage = () => {
         if (is2FAEnabled) {
           history.push('/register/2fa');
         } else {
-          history.push('/');
+          setRegisterOpen(true);
         }
       })
       .catch((error) => {
@@ -122,51 +124,60 @@ const RegisterPage = () => {
   };
 
   return (
-    <Grid container justifyContent="center">
-      <Grid
-        item
-        container
-        className={classes.root}
-        direction="column"
-        justifyContent="space-evenly"
-        spacing={3}
-      >
-        <Typo variant="h3" align="center" gutterBottom>Register Form</Typo>
-        <Typo>* 표시: 필수 입력 항목</Typo>
-        <Grid item container justifyContent="space-evenly" alignItems="center">
-          <Avatar size="large" alt={name} src={previewSrc} />
-        </Grid>
-        <form onSubmit={handleSubmit}>
-          <Grid item container className={classes.margin} justifyContent="space-between">
-            <Input onChange={handleNameChange} label="닉네임 *" value={name} helperText={helperText} error={!isValidName} />
-            <Button onClick={handleNameCheck} disabled={!isValidName}>중복 체크</Button>
+    <>
+      <Dialog
+        isOpen={isRegisterOpen}
+        title="회원가입 완료"
+        content="회원가입이 완료되어 로그인 화면으로 돌아갑니다. 서비스를 이용하시려면 로그인 해주세요."
+        buttons={<Button variant="text" onClick={() => { history.push('/'); }}>확인</Button>}
+        handleClose={() => { history.push('/'); }}
+      />
+      <Grid container justifyContent="center">
+        <Grid
+          item
+          container
+          className={classes.root}
+          direction="column"
+          justifyContent="space-evenly"
+          spacing={3}
+        >
+          <Typo variant="h3" align="center" gutterBottom>Register Form</Typo>
+          <Typo>* 표시: 필수 입력 항목</Typo>
+          <Grid item container justifyContent="space-evenly" alignItems="center">
+            <Avatar size="large" alt={name} src={previewSrc} />
           </Grid>
-          <Grid item container className={classes.margin} direction="column">
-            <Grid item container justifyContent="space-between" alignItems="center">
-              <Typo variant="subtitle1">프로필 사진 등록</Typo>
-              <MaterialButton className={classes.button} variant="contained" color="primary" component="label">
-                <Typo variant="button">파일 선택</Typo>
-                <input
-                  accept="image/*"
-                  id="contained-button-file"
-                  type="file"
-                  onChange={handleFileSelect}
-                  hidden
-                />
-              </MaterialButton>
+          <form onSubmit={handleSubmit}>
+            <Grid item container className={classes.margin} justifyContent="space-between">
+              <Input onChange={handleNameChange} label="닉네임 *" value={name} helperText={helperText} error={!isValidName} />
+              <Button onClick={handleNameCheck} disabled={!isValidName}>중복 체크</Button>
             </Grid>
-            <Typo variant="caption">{filename || '선택된 파일이 없습니다.'}</Typo>
-          </Grid>
-          <Grid item container className={classes.margin} justifyContent="space-between">
-            <Typo variant="subtitle1">2 Factor 인증 사용 여부</Typo>
-            <Switch checked={is2FAEnabled} onChange={() => { set2FA(!is2FAEnabled); }} />
-          </Grid>
-          <Grid item container justifyContent="center">
-            <Button type="submit" disabled={!isNameChecked}>회원 가입</Button>
-          </Grid>
-        </form>
+            <Grid item container className={classes.margin} direction="column">
+              <Grid item container justifyContent="space-between" alignItems="center">
+                <Typo variant="subtitle1">프로필 사진 등록</Typo>
+                <MaterialButton className={classes.button} variant="contained" color="primary" component="label">
+                  <Typo variant="button">파일 선택</Typo>
+                  <input
+                    accept="image/*"
+                    id="contained-button-file"
+                    type="file"
+                    onChange={handleFileSelect}
+                    hidden
+                  />
+                </MaterialButton>
+              </Grid>
+              <Typo variant="caption">{filename || '선택된 파일이 없습니다.'}</Typo>
+            </Grid>
+            <Grid item container className={classes.margin} justifyContent="space-between">
+              <Typo variant="subtitle1">2 Factor 인증 사용 여부</Typo>
+              <Switch checked={is2FAEnabled} onChange={() => { set2FA(!is2FAEnabled); }} />
+            </Grid>
+            <Grid item container justifyContent="center">
+              <Button type="submit" disabled={!isNameChecked}>회원 가입</Button>
+            </Grid>
+          </form>
+        </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 };
 


### PR DESCRIPTION
## 기능에 대한 설명
회원가입 완료 시 '회원가입이 완료되어 로그인 화면으로 돌아갑니다. 서비스를 이용하시려면 로그인 해주세요.'라는 내용의 Dialog가 표시되도록 하였습니다. 

## 테스트 (Optional)
- Storybook 렌더링 확인
- docker-compose로 API 서버와 연동하여 회원가입 후 Dialog 정상 표시 확인

## REFERENCE (Optional)
- [material-ui Drawer - findDOMNode is deprecated in StrictMode](https://stackoverflow.com/questions/61220424/material-ui-drawer-finddomnode-is-deprecated-in-strictmode)
  Material UI에서 제공하는 Modal 관련 컴포넌트(위 질문의 `Drawer`, 저희 프로젝트의 `Dialog` 등)가 [deprecated된 `findDOMNode`](https://ko.reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage)를 사용하고 있었습니다. 이 부분은 React.StrictMode에서 error로 console에 표시되는데, [이 답변](https://stackoverflow.com/a/64135466/13614207)을 참고하여 console error를 방지할 수 있었습니다. 사람들이 많이 사용하는 프레임워크는 최신 기술을 사용하고 있을 것이라 막연히 생각했는데 꼭 그렇지는 않다는 것을 깨달았고, 사용하는 기술에 대해 정확히 파악하는 것이 정말 중요하다는 것을 다시금 깨달았습니다.

## ISSUE

close #43
