### PR TITLE
Fix: MFAPage, MFARegisterPage의 레이아웃이 깨지는 현상 개선

### DIFF
--- a/src/components/pages/MFAPage/MFAPage.tsx
+++ b/src/components/pages/MFAPage/MFAPage.tsx
@@ -1,6 +1,7 @@
-import { makeStyles } from '@material-ui/core/styles';
-import axios from 'axios';
 import React, { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { useAppDispatch, useUserDispatch } from '../../../utils/hooks/useContext';
@@ -91,10 +92,10 @@ const MFAPage = () => {
   return (
     <LoginTemplate
       input={(
-        <>
+        <Grid item container direction="column" alignItems="center">
           <Typo className={classes.typo}>인증 번호를 정상 입력하였는데도 로그인할 수 없는 경우 담당자에게 문의해주세요.</Typo>
           <main className={classes.inputs}>{Inputs}</main>
-        </>
+        </Grid>
       )}
       button={<Button onClick={handleClick}>2FA 인증</Button>}
     />

--- a/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
+++ b/src/components/pages/MFARegisterPage/MFARegisterPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
 import Button from '../../atoms/Button/Button';
 import Dialog from '../../molecules/Dialog/Dialog';
 import LoginTemplate from '../../templates/LoginTemplate/LoginTemplate';
@@ -72,10 +73,10 @@ const MFARegisterPage = () => {
       />
       <LoginTemplate
         input={(
-          <>
-            <figcaption><Typo>Google OTP 어플리케이션을 설치하고 아래 QR 코드를 스캔해주세요.</Typo></figcaption>
+          <Grid item container direction="column" alignItems="center">
+            <figcaption><Typo>Google OTP 어플리케이션을 설치하고 QR 코드를 스캔해주세요.</Typo></figcaption>
             <figure><img className={classes.image} alt="QR Code" src={QRImageSrc} /></figure>
-          </>
+          </Grid>
         )}
         button={<Button onClick={handleClick}>2FA 등록</Button>}
       />


### PR DESCRIPTION
## 기능에 대한 설명
윈도우 크기를 크게 하면 MFAPage, MFARegisterPage의 레이아웃이 깨지던 현상을 개선했습니다.
- **문제가 발생했던 원인**: LoginTemplate이 Grid를 기반으로 작성되어 있기 때문에 LoginTemplate에 props로 넘겨준 ReactNode들은 따로 Grid 속성을 주지 않으면 item으로 간주됩니다. MFAPage, MFARegisterPage에서 Input props로 넘겨준 node 또한 Grid 속성 없이 `Fragment`로 감싸져있어 내부 컴포넌트 두 개가 각각 Grid의 item으로 간주되고 있었습니다. LoginTemplate의 Input props가 위치하는 container Grid는 기본적으로 `direction="row"` 속성을 가지는데, 이로 인해 윈도우 크기가 커지면 row로 정렬되었던 것입니다.
- **해결한 방법**: Input으로 넘길 컴포넌트를 Fragment 대신 `direction="column" alignItems="center"`속성을 가지는 container Grid로 감싸주었습니다.

## 테스트 (Optional)
- Storybook으로 렌더링 확인, 윈도우 크기를 변경하며 레이아웃 확인

## REFERENCE (Optional)
x

## ISSUE
close #48 