### PR TITLE
Feat: ChannelInfoForm Component 제작

### DIFF
--- a/src/components/atoms/Input/Input.tsx
+++ b/src/components/atoms/Input/Input.tsx
@@ -18,10 +18,11 @@ export type InputProps = {
   helperText?: string,
   defaultValue?: string,
   disabled?: boolean,
+  autoComplete?: boolean,
 };
 
 const Input = ({
-  onChange, value, error, type, label, helperText, defaultValue, disabled,
+  onChange, value, error, type, label, helperText, defaultValue, disabled, autoComplete,
 }: InputProps) => (
   defaultValue ? (
     <StyledInput
@@ -32,6 +33,7 @@ const Input = ({
       helperText={helperText}
       error={error}
       disabled={disabled}
+      autoComplete={String(autoComplete)}
     />
   ) : (
     <StyledInput
@@ -42,6 +44,7 @@ const Input = ({
       helperText={helperText}
       error={error}
       disabled={disabled}
+      autoComplete={String(autoComplete)}
     />
   )
 );
@@ -54,6 +57,7 @@ Input.defaultProps = {
   defaultValue: '',
   error: false,
   disabled: false,
+  autoComplete: false,
 };
 
 export default Input;

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.stories.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import ChannelInfoForm from './ChannelInfoForm';
+
+export default {
+  title: 'organisms/ChannelInfoForm',
+  component: ChannelInfoForm,
+} as Meta;
+
+export const Default = () => (
+  <ChannelInfoForm />
+);

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.stories.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import ChannelInfoForm from './ChannelInfoForm';
+import { ContextProvider } from '../../../utils/hooks/useContext';
 
 export default {
   title: 'organisms/ChannelInfoForm',
@@ -8,5 +9,7 @@ export default {
 } as Meta;
 
 export const Default = () => (
-  <ChannelInfoForm setOpen={() => {}} />
+  <ContextProvider>
+    <ChannelInfoForm setOpen={() => {}} />
+  </ContextProvider>
 );

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.stories.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.stories.tsx
@@ -8,5 +8,5 @@ export default {
 } as Meta;
 
 export const Default = () => (
-  <ChannelInfoForm />
+  <ChannelInfoForm setOpen={() => {}} />
 );

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -115,9 +115,9 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
       })
       .catch((error) => {
         // eslint-disable-next-line no-console
-        console.log(error.response); // FIXME: APP에서 검증 후 지우기
-        if (error.response.status === 404) {
-          setHelperTextChannelName('사용할 수 있는 닉네임입니다.');
+        console.log(error.response); // FIXME: APP에서 검증 후 지우기 404가 올바른 응답
+        if (error.response) {
+          setHelperTextChannelName('사용할 수 있는 채널명입니다.');
           setValidChannelName(true);
           setDuplicateChecked(true);
         } else toast.error(error.message);

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { Grid } from '@material-ui/core';
+import Input from '../../atoms/Input/Input';
+
+const ChannelInfoForm = () => {
+  const [password, setPassword] = useState<string>('');
+  const [isValidPassword, setValidPassword] = useState<boolean>(false);
+  const [helperTextPassword, setHelperTextPassword] = useState<string>('영문+숫자 4-12자');
+
+  const [checkPassword, setCheckPassword] = useState<string>('');
+  const [isValidCheckPassword, setValidCheckPassword] = useState<boolean>(false);
+  const [helperTextCheckPassword, setHelperTextCheckPassword] = useState<string>('영문+숫자 4-12자');
+
+  const handlePasswordChange = (event: React.ChangeEvent<Element>) => {
+    const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
+    if (value.length > 12) return;
+    if (/^[A-Za-z0-9]{4,12}$/.test(value)) {
+      setValidPassword(true);
+      setHelperTextPassword('사용할 수 있는 비밀번호');
+    } else setValidPassword(false);
+    setPassword(value);
+  };
+
+  const handleCheckPasswordChange = (event: React.ChangeEvent<Element>) => {
+    const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
+    if (value.length > 12) return;
+    if (value === password) {
+      setValidCheckPassword(true);
+      setHelperTextCheckPassword('비밀번호 일치');
+    } else {
+      setValidCheckPassword(false);
+      setHelperTextCheckPassword('비밀번호 일치하지 않음');
+    }
+    setCheckPassword(value);
+  };
+
+  return (
+    <Grid flex-direction="column" alignItems="center">
+      <Grid>
+        <Input
+          onChange={handlePasswordChange}
+          label="비밀번호 입력 *"
+          type="password"
+          value={password}
+          helperText={helperTextPassword}
+          error={!isValidPassword}
+        />
+      </Grid>
+      <Grid>
+        <Input
+          onChange={handleCheckPasswordChange}
+          label="비밀번호 검증 입력 *"
+          type="password"
+          value={checkPassword}
+          helperText={helperTextCheckPassword}
+          error={!isValidCheckPassword}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ChannelInfoForm;

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -7,7 +7,7 @@ import Typo from '../../atoms/Typo/Typo';
 const ChannelInfoForm = () => {
   const [channelName, setChannelName] = useState<string>('');
   const [isValidChannelName, setValidChannelName] = useState<boolean>(false);
-  const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 5-30자');
+  const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 5-25자');
 
   const [isToggleChecked, setToggleCheck] = useState(false);
 
@@ -22,25 +22,25 @@ const ChannelInfoForm = () => {
   const handleChannelNameChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
     if (value.length > 25) return;
-    if (value.length > 4 && /^[A-Za-z0-9]{5,12}$/.test(value)) {
+    if (/^[A-Za-z0-9]{5,25}$/.test(value)) {
       setValidChannelName(true);
       setHelperTextChannelName('사용할 수 있는 채널이름');
     } else {
       setValidChannelName(false);
-      setHelperTextChannelName('영문+숫자 5-30자');
+      setHelperTextChannelName('영문+숫자 5-25자');
     }
     setChannelName(value);
   };
 
   const handlePasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
+
     if (value.length > 12) return;
     if (/^[A-Za-z0-9]{4,12}$/.test(value)) {
       setValidPassword(true);
       setHelperTextPassword('사용할 수 있는 비밀번호');
     } else setValidPassword(false);
-    setPassword(value);
-    // FIXME: 비밀번호 검증 후, 비밀번호를 바꿨을 때 생기는 문제를 위한 코드
+    // NOTE: 아래는 비밀번호 검증 후, 비밀번호를 바꿨을 때 생기는 문제를 위한 코드
     if (checkPassword === value) {
       setValidCheckPassword(true);
       setHelperTextCheckPassword('비밀번호 일치');
@@ -48,10 +48,12 @@ const ChannelInfoForm = () => {
       setValidCheckPassword(false);
       setHelperTextCheckPassword('비밀번호 일치하지 않음');
     }
+    setPassword(value);
   };
 
   const handleCheckPasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
+
     if (value.length > 12) return;
     if (value === password) {
       setValidCheckPassword(true);
@@ -63,53 +65,51 @@ const ChannelInfoForm = () => {
     setCheckPassword(value);
   };
 
-  const PasswordInput = () => (
-    <Grid container flex-direction="column">
-      <Grid item container>
-        <Input
-          onChange={handlePasswordChange}
-          label="비밀번호 입력 *"
-          type="password"
-          value={password}
-          helperText={helperTextPassword}
-          error={!isValidPassword}
-        />
-      </Grid>
-      <Grid item container>
-        <Input
-          onChange={handleCheckPasswordChange}
-          label="비밀번호 검증 입력 *"
-          type="password"
-          value={checkPassword}
-          helperText={helperTextCheckPassword}
-          error={!isValidCheckPassword}
-        />
-      </Grid>
-    </Grid>
-  );
-
   return (
     <Grid container flex-direction="column" alignItems="center">
-      <Grid item>
-        <Input
-          onChange={handleChannelNameChange}
-          label="채널명 입력 *"
-          value={channelName}
-          helperText={helperTextChannelName}
-          error={!isValidChannelName}
-        />
-      </Grid>
-      <Grid item container>
-        <Switch
-          name="private toggle"
-          checked={isToggleChecked}
-          onChange={() => { setToggleCheck(!isToggleChecked); }}
-        />
-        <Typo>Private</Typo>
-      </Grid>
-      <Grid item>
-        {isToggleChecked && <PasswordInput />}
-      </Grid>
+      <form>
+        <Grid item>
+          <Input
+            onChange={handleChannelNameChange}
+            label="채널명 입력 *"
+            value={channelName}
+            helperText={helperTextChannelName}
+            error={!isValidChannelName}
+          />
+        </Grid>
+        <Grid item container>
+          <Switch
+            name="private toggle"
+            checked={isToggleChecked}
+            onChange={() => { setToggleCheck(!isToggleChecked); }}
+          />
+          <Typo>Private</Typo>
+        </Grid>
+        <Grid item>
+          {isToggleChecked && (
+          <>
+            <Input
+              onChange={handlePasswordChange}
+              label="비밀번호 입력 *"
+              type="password"
+              value={password}
+              helperText={helperTextPassword}
+              error={!isValidPassword}
+              autoComplete
+            />
+            <Input
+              onChange={handleCheckPasswordChange}
+              label="비밀번호 검증 입력 *"
+              type="password"
+              value={checkPassword}
+              helperText={helperTextCheckPassword}
+              error={!isValidCheckPassword}
+              autoComplete
+            />
+          </>
+          )}
+        </Grid>
+      </form>
     </Grid>
   );
 };

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -12,7 +12,7 @@ import Button from '../../atoms/Button/Button';
 const useStyles = makeStyles({
   root: {
     padding: '5em 0',
-    width: '300px',
+    width: '350px',
   },
   margin: {
     marginBottom: '1em',
@@ -114,7 +114,8 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
         setValidChannelName(false);
       })
       .catch((error) => {
-        console.log(error.response);
+        // eslint-disable-next-line no-console
+        console.log(error.response); // FIXME: APP에서 검증 후 지우기
         if (error.response.status === 404) {
           setHelperTextChannelName('사용할 수 있는 닉네임입니다.');
           setValidChannelName(true);

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -19,20 +19,30 @@ const useStyles = makeStyles({
   },
 });
 
+const CHANNEL_NAME_AVAILABLE = '사용할 수 있는 채널이름';
+const CHANNEL_NAME_HELPER_TEXT = '영문+숫자 5-25자';
+const CHANNEL_PASSWORD_AVAILABLE = '사용할 수 있는 비밀번호';
+const CHANNEL_PASSWORD_HELPER_TEXT = '영문+숫자 4-12자';
+const PASSWORD_CHECK_YES = '비밀번호 일치';
+const PASSWORD_CHECK_NO = '비밀번호 일치하지 않음';
+
 // eslint-disable-next-line no-unused-vars
 type ChannelInfoFormProps = { setOpen: (isOpen:boolean) => void };
 
 const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
   const [channelName, setChannelName] = useState<string>('');
   const [isValidChannelName, setValidChannelName] = useState<boolean>(false);
-  const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 5-25자');
+  // eslint-disable-next-line max-len
+  const [helperTextChannelName, setHelperTextChannelName] = useState<string>(CHANNEL_NAME_HELPER_TEXT);
   const [isToggleChecked, setToggleCheck] = useState(false);
   const [password, setPassword] = useState<string>('');
   const [isValidPassword, setValidPassword] = useState<boolean>(false);
-  const [helperTextPassword, setHelperTextPassword] = useState<string>('영문+숫자 4-12자');
+  // eslint-disable-next-line max-len
+  const [helperTextPassword, setHelperTextPassword] = useState<string>(CHANNEL_PASSWORD_HELPER_TEXT);
   const [checkPassword, setCheckPassword] = useState<string>('');
   const [isValidCheckPassword, setValidCheckPassword] = useState<boolean>(false);
-  const [helperTextCheckPassword, setHelperTextCheckPassword] = useState<string>('영문+숫자 4-12자');
+  // eslint-disable-next-line max-len
+  const [helperTextCheckPassword, setHelperTextCheckPassword] = useState<string>(CHANNEL_PASSWORD_HELPER_TEXT);
   const classes = useStyles();
 
   const handleChannelNameChange = (event: React.ChangeEvent<Element>) => {
@@ -40,10 +50,10 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
     if (value.length > 25) return;
     if (/^[A-Za-z0-9]{5,25}$/.test(value)) {
       setValidChannelName(true);
-      setHelperTextChannelName('사용할 수 있는 채널이름');
+      setHelperTextChannelName(CHANNEL_NAME_AVAILABLE);
     } else {
       setValidChannelName(false);
-      setHelperTextChannelName('영문+숫자 5-25자');
+      setHelperTextChannelName(CHANNEL_NAME_HELPER_TEXT);
     }
     setChannelName(value);
   };
@@ -53,14 +63,14 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
     if (value.length > 12) return;
     if (/^[A-Za-z0-9]{4,12}$/.test(value)) {
       setValidPassword(true);
-      setHelperTextPassword('사용할 수 있는 비밀번호');
+      setHelperTextPassword(CHANNEL_PASSWORD_AVAILABLE);
     } else setValidPassword(false);
     if (checkPassword === value) {
       setValidCheckPassword(true);
-      setHelperTextCheckPassword('비밀번호 일치');
+      setHelperTextCheckPassword(PASSWORD_CHECK_YES);
     } else {
       setValidCheckPassword(false);
-      setHelperTextCheckPassword('비밀번호 일치하지 않음');
+      setHelperTextCheckPassword(PASSWORD_CHECK_NO);
     }
     setPassword(value);
   };
@@ -70,10 +80,10 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
     if (value.length > 12) return;
     if (value === password) {
       setValidCheckPassword(true);
-      setHelperTextCheckPassword('비밀번호 일치');
+      setHelperTextCheckPassword(PASSWORD_CHECK_YES);
     } else {
       setValidCheckPassword(false);
-      setHelperTextCheckPassword('비밀번호 일치하지 않음');
+      setHelperTextCheckPassword(PASSWORD_CHECK_NO);
     }
     setCheckPassword(value);
   };
@@ -81,6 +91,15 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     // FIXME: API 확정된 후 추가하기
+  };
+
+  const isValidForm = () => {
+    if (!isToggleChecked) {
+      if (isValidChannelName) return true;
+      return false;
+    }
+    if (isValidChannelName && isValidPassword && isValidCheckPassword) return true;
+    return false;
   };
 
   return (
@@ -157,9 +176,7 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
             </Button>
             <Button
               type="submit"
-              disabled={(!isToggleChecked && !isValidChannelName)
-                || (isToggleChecked && (!isValidPassword || !isValidCheckPassword
-                  || !isValidChannelName))}
+              disabled={!isValidForm()}
               className={classes.button}
             >
               채널 만들기

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from 'react';
 import { Grid } from '@material-ui/core';
 import Input from '../../atoms/Input/Input';
+import Switch from '../../atoms/Switch/Switch';
+import Typo from '../../atoms/Typo/Typo';
 
 const ChannelInfoForm = () => {
   const [channelName, setChannelName] = useState<string>('');
   const [isValidChannelName, setValidChannelName] = useState<boolean>(false);
-  const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 30자 이내');
+  const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 5-30자');
+
+  const [isToggleChecked, setToggleCheck] = useState(false);
 
   const [password, setPassword] = useState<string>('');
   const [isValidPassword, setValidPassword] = useState<boolean>(false);
@@ -18,9 +22,12 @@ const ChannelInfoForm = () => {
   const handleChannelNameChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
     if (value.length > 25) return;
-    if (value.length > 0) {
+    if (value.length > 4 && /^[A-Za-z0-9]{5,12}$/.test(value)) {
       setValidChannelName(true);
       setHelperTextChannelName('사용할 수 있는 채널이름');
+    } else {
+      setValidChannelName(false);
+      setHelperTextChannelName('영문+숫자 5-30자');
     }
     setChannelName(value);
   };
@@ -33,6 +40,14 @@ const ChannelInfoForm = () => {
       setHelperTextPassword('사용할 수 있는 비밀번호');
     } else setValidPassword(false);
     setPassword(value);
+    // FIXME: 비밀번호 검증 후, 비밀번호를 바꿨을 때 생기는 문제를 위한 코드
+    if (checkPassword === value) {
+      setValidCheckPassword(true);
+      setHelperTextCheckPassword('비밀번호 일치');
+    } else {
+      setValidCheckPassword(false);
+      setHelperTextCheckPassword('비밀번호 일치하지 않음');
+    }
   };
 
   const handleCheckPasswordChange = (event: React.ChangeEvent<Element>) => {
@@ -48,18 +63,9 @@ const ChannelInfoForm = () => {
     setCheckPassword(value);
   };
 
-  return (
-    <Grid flex-direction="column" alignItems="center">
-      <Grid>
-        <Input
-          onChange={handleChannelNameChange}
-          label="채널명 입력 *"
-          value={channelName}
-          helperText={helperTextChannelName}
-          error={!isValidChannelName}
-        />
-      </Grid>
-      <Grid>
+  const PasswordInput = () => (
+    <Grid container flex-direction="column">
+      <Grid item container>
         <Input
           onChange={handlePasswordChange}
           label="비밀번호 입력 *"
@@ -69,7 +75,7 @@ const ChannelInfoForm = () => {
           error={!isValidPassword}
         />
       </Grid>
-      <Grid>
+      <Grid item container>
         <Input
           onChange={handleCheckPasswordChange}
           label="비밀번호 검증 입력 *"
@@ -78,6 +84,31 @@ const ChannelInfoForm = () => {
           helperText={helperTextCheckPassword}
           error={!isValidCheckPassword}
         />
+      </Grid>
+    </Grid>
+  );
+
+  return (
+    <Grid container flex-direction="column" alignItems="center">
+      <Grid item>
+        <Input
+          onChange={handleChannelNameChange}
+          label="채널명 입력 *"
+          value={channelName}
+          helperText={helperTextChannelName}
+          error={!isValidChannelName}
+        />
+      </Grid>
+      <Grid item container>
+        <Switch
+          name="private toggle"
+          checked={isToggleChecked}
+          onChange={() => { setToggleCheck(!isToggleChecked); }}
+        />
+        <Typo>Private</Typo>
+      </Grid>
+      <Grid item>
+        {isToggleChecked && <PasswordInput />}
       </Grid>
     </Grid>
   );

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -3,6 +3,10 @@ import { Grid } from '@material-ui/core';
 import Input from '../../atoms/Input/Input';
 
 const ChannelInfoForm = () => {
+  const [channelName, setChannelName] = useState<string>('');
+  const [isValidChannelName, setValidChannelName] = useState<boolean>(false);
+  const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 30자 이내');
+
   const [password, setPassword] = useState<string>('');
   const [isValidPassword, setValidPassword] = useState<boolean>(false);
   const [helperTextPassword, setHelperTextPassword] = useState<string>('영문+숫자 4-12자');
@@ -10,6 +14,16 @@ const ChannelInfoForm = () => {
   const [checkPassword, setCheckPassword] = useState<string>('');
   const [isValidCheckPassword, setValidCheckPassword] = useState<boolean>(false);
   const [helperTextCheckPassword, setHelperTextCheckPassword] = useState<string>('영문+숫자 4-12자');
+
+  const handleChannelNameChange = (event: React.ChangeEvent<Element>) => {
+    const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
+    if (value.length > 25) return;
+    if (value.length > 0) {
+      setValidChannelName(true);
+      setHelperTextChannelName('사용할 수 있는 채널이름');
+    }
+    setChannelName(value);
+  };
 
   const handlePasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
@@ -36,6 +50,15 @@ const ChannelInfoForm = () => {
 
   return (
     <Grid flex-direction="column" alignItems="center">
+      <Grid>
+        <Input
+          onChange={handleChannelNameChange}
+          label="채널명 입력 *"
+          value={channelName}
+          helperText={helperTextChannelName}
+          error={!isValidChannelName}
+        />
+      </Grid>
       <Grid>
         <Input
           onChange={handlePasswordChange}

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -1,23 +1,35 @@
 import React, { useState } from 'react';
-import { Grid } from '@material-ui/core';
+import { Grid, makeStyles } from '@material-ui/core';
 import Input from '../../atoms/Input/Input';
 import Switch from '../../atoms/Switch/Switch';
 import Typo from '../../atoms/Typo/Typo';
+import Button from '../../atoms/Button/Button';
+
+const useStyles = makeStyles({
+  root: {
+    padding: '5em 0',
+    width: '300px',
+  },
+  margin: {
+    marginBottom: '1em',
+  },
+  button: {
+    margin: '2.15em',
+  },
+});
 
 const ChannelInfoForm = () => {
   const [channelName, setChannelName] = useState<string>('');
   const [isValidChannelName, setValidChannelName] = useState<boolean>(false);
   const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 5-25자');
-
   const [isToggleChecked, setToggleCheck] = useState(false);
-
   const [password, setPassword] = useState<string>('');
   const [isValidPassword, setValidPassword] = useState<boolean>(false);
   const [helperTextPassword, setHelperTextPassword] = useState<string>('영문+숫자 4-12자');
-
   const [checkPassword, setCheckPassword] = useState<string>('');
   const [isValidCheckPassword, setValidCheckPassword] = useState<boolean>(false);
   const [helperTextCheckPassword, setHelperTextCheckPassword] = useState<string>('영문+숫자 4-12자');
+  const classes = useStyles();
 
   const handleChannelNameChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
@@ -65,51 +77,87 @@ const ChannelInfoForm = () => {
     setCheckPassword(value);
   };
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
   return (
-    <Grid container flex-direction="column" alignItems="center">
-      <form>
-        <Grid item>
-          <Input
-            onChange={handleChannelNameChange}
-            label="채널명 입력 *"
-            value={channelName}
-            helperText={helperTextChannelName}
-            error={!isValidChannelName}
-          />
-        </Grid>
-        <Grid item container>
-          <Switch
-            name="private toggle"
-            checked={isToggleChecked}
-            onChange={() => { setToggleCheck(!isToggleChecked); }}
-          />
-          <Typo>Private</Typo>
-        </Grid>
-        <Grid item>
-          {isToggleChecked && (
-          <>
+    <Grid container justifyContent="center">
+      <Grid
+        item
+        container
+        className={classes.root}
+        direction="column"
+        justifyContent="space-evenly"
+        spacing={3}
+      >
+        <Typo variant="h3" align="center" gutterBottom>Channel Form</Typo>
+        <Typo className={classes.margin}>* 표시: 필수 입력 항목</Typo>
+        <form onSubmit={handleSubmit}>
+          <Grid item container alignItems="center" justifyContent="center">
             <Input
-              onChange={handlePasswordChange}
-              label="비밀번호 입력 *"
-              type="password"
-              value={password}
-              helperText={helperTextPassword}
-              error={!isValidPassword}
-              autoComplete
+              onChange={handleChannelNameChange}
+              label="채널명 입력 *"
+              value={channelName}
+              helperText={helperTextChannelName}
+              error={!isValidChannelName}
             />
-            <Input
-              onChange={handleCheckPasswordChange}
-              label="비밀번호 검증 입력 *"
-              type="password"
-              value={checkPassword}
-              helperText={helperTextCheckPassword}
-              error={!isValidCheckPassword}
-              autoComplete
+          </Grid>
+          <Grid item container alignItems="center" justifyContent="center">
+            <Switch
+              name="private toggle"
+              checked={isToggleChecked}
+              onChange={() => { setToggleCheck(!isToggleChecked); }}
             />
-          </>
-          )}
-        </Grid>
-      </form>
+            <Typo>Private</Typo>
+          </Grid>
+          <Grid>
+            {isToggleChecked && (
+              <Grid
+                item
+                container
+                direction="column"
+                justifyContent="center"
+                alignItems="center"
+              >
+                <Grid item>
+                  <Input
+                    onChange={handlePasswordChange}
+                    label="비밀번호 입력 *"
+                    type="password"
+                    value={password}
+                    helperText={helperTextPassword}
+                    error={!isValidPassword}
+                    autoComplete
+                  />
+                </Grid>
+                <Grid item>
+                  <Input
+                    onChange={handleCheckPasswordChange}
+                    label="비밀번호 검증 입력 *"
+                    type="password"
+                    value={checkPassword}
+                    helperText={helperTextCheckPassword}
+                    error={!isValidCheckPassword}
+                    autoComplete
+                  />
+                </Grid>
+              </Grid>
+            )}
+          </Grid>
+          <Grid container justifyContent="center">
+            <Button
+              type="submit"
+              disabled={(!isToggleChecked && !isValidChannelName)
+                || (isToggleChecked && (!isValidPassword || !isValidCheckPassword
+                  || !isValidChannelName))}
+              className={classes.button}
+            >
+              채널 만들기
+            </Button>
+          </Grid>
+        </form>
+      </Grid>
     </Grid>
   );
 };

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -20,9 +20,9 @@ const useStyles = makeStyles({
 });
 
 const CHANNEL_NAME_AVAILABLE = '사용할 수 있는 채널이름';
-const CHANNEL_NAME_HELPER_TEXT = '영문+숫자 5-25자';
+const CHANNEL_NAME_HELPER_TEXT = '맨 앞, 뒤 공백 없는 모든 문자 3-18자';
 const CHANNEL_PASSWORD_AVAILABLE = '사용할 수 있는 비밀번호';
-const CHANNEL_PASSWORD_HELPER_TEXT = '영문+숫자 4-12자';
+const CHANNEL_PASSWORD_HELPER_TEXT = '공백 제외 모든 문자+숫자 8-32자';
 const PASSWORD_CHECK_YES = '비밀번호 일치';
 const PASSWORD_CHECK_NO = '비밀번호 일치하지 않음';
 
@@ -47,8 +47,8 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
 
   const handleChannelNameChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
-    if (value.length > 25) return;
-    if (/^[A-Za-z0-9]{5,25}$/.test(value)) {
+    if (value.length > 18) return;
+    if (/^[^\s]+(\s+[^\s]+)*$/.test(value) && /^.{3,18}$/.test(value)) {
       setValidChannelName(true);
       setHelperTextChannelName(CHANNEL_NAME_AVAILABLE);
     } else {
@@ -60,11 +60,14 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
 
   const handlePasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
-    if (value.length > 12) return;
-    if (/^[A-Za-z0-9]{4,12}$/.test(value)) {
+    if (value.length > 32) return;
+    if (/^[\S]{8,32}$/.test(value)) {
       setValidPassword(true);
       setHelperTextPassword(CHANNEL_PASSWORD_AVAILABLE);
-    } else setValidPassword(false);
+    } else {
+      setValidPassword(false);
+      setHelperTextPassword(CHANNEL_PASSWORD_HELPER_TEXT);
+    }
     if (checkPassword === value) {
       setValidCheckPassword(true);
       setHelperTextCheckPassword(PASSWORD_CHECK_YES);
@@ -77,7 +80,7 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
 
   const handleCheckPasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
-    if (value.length > 12) return;
+    if (value.length > 32) return;
     if (value === password) {
       setValidCheckPassword(true);
       setHelperTextCheckPassword(PASSWORD_CHECK_YES);

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -114,9 +114,7 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
         setValidChannelName(false);
       })
       .catch((error) => {
-        // eslint-disable-next-line no-console
-        console.log(error.response); // FIXME: APP에서 검증 후 지우기 404가 올바른 응답
-        if (error.response) {
+        if (error.response && error.response.status === 404) {
           setHelperTextChannelName('사용할 수 있는 채널명입니다.');
           setValidChannelName(true);
           setDuplicateChecked(true);
@@ -144,7 +142,6 @@ const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
         justifyContent="space-evenly"
         spacing={3}
       >
-        <Typo variant="h3" align="center" gutterBottom>Channel Form</Typo>
         <Typo className={classes.margin}>* 표시: 필수 입력 항목</Typo>
         <form onSubmit={handleSubmit}>
           <Grid item container className={classes.margin} justifyContent="center">

--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -14,11 +14,15 @@ const useStyles = makeStyles({
     marginBottom: '1em',
   },
   button: {
-    margin: '2.15em',
+    marginTop: '1.68em',
+    width: '32.8%',
   },
 });
 
-const ChannelInfoForm = () => {
+// eslint-disable-next-line no-unused-vars
+type ChannelInfoFormProps = { setOpen: (isOpen:boolean) => void };
+
+const ChannelInfoForm = ({ setOpen }: ChannelInfoFormProps) => {
   const [channelName, setChannelName] = useState<string>('');
   const [isValidChannelName, setValidChannelName] = useState<boolean>(false);
   const [helperTextChannelName, setHelperTextChannelName] = useState<string>('영문+숫자 5-25자');
@@ -46,13 +50,11 @@ const ChannelInfoForm = () => {
 
   const handlePasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
-
     if (value.length > 12) return;
     if (/^[A-Za-z0-9]{4,12}$/.test(value)) {
       setValidPassword(true);
       setHelperTextPassword('사용할 수 있는 비밀번호');
     } else setValidPassword(false);
-    // NOTE: 아래는 비밀번호 검증 후, 비밀번호를 바꿨을 때 생기는 문제를 위한 코드
     if (checkPassword === value) {
       setValidCheckPassword(true);
       setHelperTextCheckPassword('비밀번호 일치');
@@ -65,7 +67,6 @@ const ChannelInfoForm = () => {
 
   const handleCheckPasswordChange = (event: React.ChangeEvent<Element>) => {
     const { value } = (event as React.ChangeEvent<HTMLInputElement>).target;
-
     if (value.length > 12) return;
     if (value === password) {
       setValidCheckPassword(true);
@@ -79,6 +80,7 @@ const ChannelInfoForm = () => {
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    // FIXME: API 확정된 후 추가하기
   };
 
   return (
@@ -146,6 +148,13 @@ const ChannelInfoForm = () => {
             )}
           </Grid>
           <Grid container justifyContent="center">
+            <Button
+              variant="text"
+              className={classes.button}
+              onClick={() => { setOpen(false); }}
+            >
+              Cancel
+            </Button>
             <Button
               type="submit"
               disabled={(!isToggleChecked && !isValidChannelName)


### PR DESCRIPTION
## 기능에 대한 설명
 `Channel Page`에서 `User`가 `Channel`을 추가할 때, 사용되는 양식을 제작했습니다. `Channel`을 **공개/비공개**로 만들 수 있도록 만들었고, **공개**로 선택했을 경우, `Channel` 제목을 _영문+숫자 5-25자_ 로 만들면 `Channel form`을 제출할 수 있게 만들었습니다. **비공개**로 했을 경우, 비밀번호 양식을 _영문+숫자 4-12자_ 로 맞춰줘야합니다. `Channel form`을 만족하는 내용을 적어주면, `채널 만들기` 버튼이 활성화됩니다.  


## 테스트 (Optional)

- [x] 각 브라우저에서 storybook으로 랜더링 확인
- [x] 각 브라우저에서 console error 확인

## REFERENCE (Optional)

[Dialog](https://material-ui.com/api/dialog/), [UserInfoForm](https://github.com/404-DriverNotFound/frontend-b/blob/feat/Page-Profile%2347/src/components/organisms/UserInfoForm/UserInfoForm.tsx), [ProfilePage](https://github.com/404-DriverNotFound/frontend-b/blob/feat/Page-Profile%2347/src/components/pages/ProfilePage/ProfilePage.tsx)

## ISSUE

close #63 