### PR TITLE
Feat: 채팅 기능을 위한 기반 작업

### DIFF
--- a/src/components/Chat.stories.tsx
+++ b/src/components/Chat.stories.tsx
@@ -6,21 +6,26 @@ import ListItem from './atoms/ListItem/ListItem';
 import List from './atoms/List/List';
 import ChatInput from './atoms/ChatInput/ChatInput';
 import { ContextProvider } from '../utils/hooks/useContext';
-import CommunityPage from './pages/CommunityPage/CommunityPage';
+import Typo from './atoms/Typo/Typo';
 
 export default {
   component: MainTemplate,
   title: 'tests/Chat',
 } as Meta;
 
-const addNewChat = (prev: string[], newChat: string) => {
+type ChatType = {
+  content: string,
+  date: string,
+};
+
+const addNewChat = (prev: ChatType[], content: string) => {
   const temp = prev.slice();
-  temp.unshift(newChat);
+  temp.unshift({ content, date: Date.now().toString() });
   return temp;
 };
 
 const Chat = () => {
-  const [chat, setChat] = useState<string[]>(['0']);
+  const [chat, setChat] = useState<ChatType[]>([]);
   const [value, setValue] = useState<string>('');
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -30,7 +35,7 @@ const Chat = () => {
   return (
     <>
       <List height="75vh" scroll reverse>
-        {chat.map((one) => <ListItem>{one}</ListItem>)}
+        {chat.map(({ content, date }) => <ListItem key={date}>{content}</ListItem>)}
       </List>
       <ChatInput
         onSubmit={(e) => {
@@ -50,7 +55,15 @@ export const ChatTest = () => (
   <BrowserRouter>
     <ContextProvider>
       <MainTemplate
-        main={<CommunityPage />}
+        main={(
+          <>
+            <Typo variant="h3" gutterBottom>Chat Test Page</Typo>
+            <Typo variant="h5">List</Typo>
+            <List />
+            <Typo variant="h5">List</Typo>
+            <List height="35vh" />
+          </>
+        )}
         chat={<Chat />}
       />
     </ContextProvider>

--- a/src/components/Chat.stories.tsx
+++ b/src/components/Chat.stories.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import MainTemplate from './templates/MainTemplate/MainTemplate';
+import ListItem from './atoms/ListItem/ListItem';
+import List from './atoms/List/List';
+import ChatInput from './atoms/ChatInput/ChatInput';
+import { ContextProvider } from '../utils/hooks/useContext';
+import CommunityPage from './pages/CommunityPage/CommunityPage';
+
+export default {
+  component: MainTemplate,
+  title: 'tests/Chat',
+} as Meta;
+
+const addNewChat = (prev: string[], newChat: string) => {
+  const temp = prev.slice();
+  temp.unshift(newChat);
+  return temp;
+};
+
+const Chat = () => {
+  const [chat, setChat] = useState<string[]>(['0']);
+  const [value, setValue] = useState<string>('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+  };
+
+  return (
+    <>
+      <List height="75vh" scroll reverse>
+        {chat.map((one) => <ListItem>{one}</ListItem>)}
+      </List>
+      <ChatInput
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (value === '') return;
+          setChat((prev) => addNewChat(prev, value));
+          setValue('');
+        }}
+        onChange={handleChange}
+        value={value}
+      />
+    </>
+  );
+};
+
+export const ChatTest = () => (
+  <BrowserRouter>
+    <ContextProvider>
+      <MainTemplate
+        main={<CommunityPage />}
+        chat={<Chat />}
+      />
+    </ContextProvider>
+  </BrowserRouter>
+);

--- a/src/components/atoms/ChatInput/ChatInput.stories.tsx
+++ b/src/components/atoms/ChatInput/ChatInput.stories.tsx
@@ -1,0 +1,29 @@
+/* eslint-disable no-console */
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react';
+import ChatInput from './ChatInput';
+
+export default {
+  component: ChatInput,
+  title: 'atoms/ChatInput',
+} as Meta;
+
+export const Default = () => {
+  const [value, setValue] = useState<string>('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+  };
+
+  return (
+    <ChatInput
+      onSubmit={(e) => {
+        e.preventDefault();
+        setValue('');
+        console.log(value);
+      }}
+      onChange={handleChange}
+      value={value}
+    />
+  );
+};

--- a/src/components/atoms/ChatInput/ChatInput.tsx
+++ b/src/components/atoms/ChatInput/ChatInput.tsx
@@ -1,23 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-
-const useStyles = makeStyles({
-  root: {
-    '&::-webkit-scrollbar': {
-      width: '10px',
-    },
-    '&::-webkit-scrollbar-thumb': {
-      backgroundColor: 'lightgray',
-      borderRadius: '5px',
-    },
-    '&::-webkit-scrollbar-track': {
-      backgroundColor: 'transparent',
-      overflow: 'hidden',
-    },
-    scrollbarColor: 'lightgray transparent',
-  },
-});
 
 type ChatInputProps = {
   onSubmit: React.FormEventHandler<HTMLFormElement>,
@@ -25,22 +7,17 @@ type ChatInputProps = {
   value?: string,
 };
 
-const ChatInput = ({ onSubmit, onChange, value }: ChatInputProps) => {
-  const classes = useStyles();
-
-  return (
-    <form onSubmit={onSubmit}>
-      <TextField
-        className={classes.root}
-        onChange={onChange}
-        value={value}
-        label="Chat on here!"
-        variant="outlined"
-        fullWidth
-      />
-    </form>
-  );
-};
+const ChatInput = ({ onSubmit, onChange, value }: ChatInputProps) => (
+  <form onSubmit={onSubmit}>
+    <TextField
+      onChange={onChange}
+      value={value}
+      label="Chat on here!"
+      variant="outlined"
+      fullWidth
+    />
+  </form>
+);
 
 ChatInput.defaultProps = {
   value: '',

--- a/src/components/atoms/ChatInput/ChatInput.tsx
+++ b/src/components/atoms/ChatInput/ChatInput.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
+
+const useStyles = makeStyles({
+  root: {
+    '&::-webkit-scrollbar': {
+      width: '10px',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      backgroundColor: 'lightgray',
+      borderRadius: '5px',
+    },
+    '&::-webkit-scrollbar-track': {
+      backgroundColor: 'transparent',
+      overflow: 'hidden',
+    },
+    scrollbarColor: 'lightgray transparent',
+  },
+});
+
+type ChatInputProps = {
+  onSubmit: React.FormEventHandler<HTMLFormElement>,
+  onChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>,
+  value?: string,
+};
+
+const ChatInput = ({ onSubmit, onChange, value }: ChatInputProps) => {
+  const classes = useStyles();
+
+  return (
+    <form onSubmit={onSubmit}>
+      <TextField
+        className={classes.root}
+        onChange={onChange}
+        value={value}
+        label="Chat on here!"
+        variant="outlined"
+        fullWidth
+      />
+    </form>
+  );
+};
+
+ChatInput.defaultProps = {
+  value: '',
+};
+
+export default ChatInput;

--- a/src/components/atoms/List/List.tsx
+++ b/src/components/atoms/List/List.tsx
@@ -39,17 +39,20 @@ const useStyles = makeStyles({
 type ListProps = {
   height?: string,
   scroll?: boolean,
+  reverse?: boolean,
   children?: React.ReactNode,
 };
 
-const List = ({ height, scroll, children }: ListProps) => {
+const List = ({
+  height, scroll, reverse, children,
+}: ListProps) => {
   const classes = useStyles({ height, scroll } as StyleProps);
   return (
     <Grid
       item
       container
       className={classes.root}
-      direction="column"
+      direction={reverse ? 'column-reverse' : 'column'}
       justifyContent="flex-start"
       alignItems="stretch"
       wrap="nowrap"
@@ -68,6 +71,7 @@ const List = ({ height, scroll, children }: ListProps) => {
 List.defaultProps = {
   height: '25vh',
   scroll: false,
+  reverse: false,
   children: null,
 };
 


### PR DESCRIPTION
## 기능에 대한 설명
채팅 기능을 위한 기반 작업을 진행하였습니다.
- List 컴포넌트를 채팅에서도 사용할 수 있도록 확장
  - `reverse` props를 추가하면 Grid의 direction이 `column-reverse`로 설정되도록 구현
- ChatInput 컴포넌트 제작
- Story 작성 (Tests-Chat-Chat Test)
<br>

- 추후 채팅 컴포넌트 구현 시 고려하면 좋을 것 같은 점

  ![image](https://user-images.githubusercontent.com/57004991/131968011-68d9865c-3934-4600-a598-d9caa5b5f396.png)
  `<ListItem />`  컴포넌트에서는 한국어의 경우 띄어쓰기 없이 width 이상의 글을 써도 자동 줄바꿈이 되는데 영어는 자동 줄바꿈이 되지 않았습니다. 채팅용 말풍선(?) 컴포넌트를 구현할 때에는 [`word-break: break-all;` 같은 속성](https://developer.mozilla.org/ko/docs/Web/CSS/word-break)을 넣어 줄바꿈까지 고려해주면 좋을 것 같습니다.

## 테스트 (Optional)
- [x] Storybook으로 렌더링 확인

## REFERENCE (Optional)
-

## ISSUE
close #75