### PR TITLE
Fix: CommunityPage의 오류 수정

### DIFF
--- a/src/components/organisms/ProfileCard/ProfileCard.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.tsx
@@ -404,7 +404,7 @@ const ProfileCard = ({
     }
     if (friendButton) array.push(friendButton);
     if (profile || relationship === 'BLOCKING') array.push(blockButton);
-    return relationship === 'NONE' ? otherButtons : array.concat(otherButtons);
+    return (!profile && relationship === 'NONE') ? otherButtons : array.concat(otherButtons);
   };
 
   const Buttons = buttonArray().map((button) => (

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -40,7 +40,7 @@ const UserList = ({ type }: ListProps) => {
   const path = type === 'all' ? makeAPIPath('/users') : makeAPIPath(`/${type}`);
   const relationship = relationships[type];
   const [users, setUsers] = useState<RelatedInfoType[]>([]);
-  const [isListEnd, setListEnd] = useState(false);
+  const [isListEnd, setListEnd] = useState(true);
   const [page, setPage] = useState<number>(1);
   const {
     isOpen, setOpen, dialog, setDialog,
@@ -86,13 +86,15 @@ const UserList = ({ type }: ListProps) => {
         .then(({ data }: { data: RawUserInfoType[] }) => {
           const typed: UserInfoType[] = data;
           setUsers((prev) => prev.concat(typed.map((oneUser) => ({ ...oneUser, avatar: makeAPIPath(`/${oneUser.avatar}`), relationship: 'REQUESTED' }))));
+          setListEnd(false);
         })
         .catch((error) => {
           source.cancel();
           toast.error(error.message);
           setListEnd(true);
         });
-    }
+    } else setListEnd(false);
+
     return () => {
       source.cancel();
       setUsers([]);
@@ -121,28 +123,27 @@ const UserList = ({ type }: ListProps) => {
           />
         </ListItem>
       ))}
+      {!isListEnd && (
       <div
         style={{ display: 'flex', justifyContent: 'center', marginTop: '4px' }}
-        hidden={isListEnd}
         ref={isListEnd ? null : setRef as React.LegacyRef<HTMLDivElement>}
       >
-        {!isListEnd && (
-          <Grid
-            item
-            container
-            direction="column"
-            justifyContent="flex-start"
-            alignItems="stretch"
-            wrap="nowrap"
-            spacing={1}
-            xs={12}
-          >
-            <ListItem><ProfileCardSkeleton /></ListItem>
-            <ListItem><ProfileCardSkeleton /></ListItem>
-            <ListItem><ProfileCardSkeleton /></ListItem>
-          </Grid>
-        )}
+        <Grid
+          item
+          container
+          direction="column"
+          justifyContent="flex-start"
+          alignItems="stretch"
+          wrap="nowrap"
+          spacing={1}
+          xs={12}
+        >
+          <ListItem><ProfileCardSkeleton /></ListItem>
+          <ListItem><ProfileCardSkeleton /></ListItem>
+          <ListItem><ProfileCardSkeleton /></ListItem>
+        </Grid>
       </div>
+      )}
     </>
   );
 };

--- a/src/utils/hooks/useIntersect.ts
+++ b/src/utils/hooks/useIntersect.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 
 const baseOption = {
   root: null,
-  threshold: 0.8,
+  threshold: 0.3,
   rootMargin: '0px',
 };
 


### PR DESCRIPTION
## 기능에 대한 설명
- relation이 'NONE'인 사용자의 ProfilePage에서 친구/차단 버튼이 보이지 않는 문제
  -> CommunityPage의 전체 유저 목록에서 친구/차단 버튼을 보이지 않게 하기 위해 적용한 로직이 잘못되어 있었습니다. 그래서 해당 부분에 profile 여부를 판별하는 로직을 추가하였습니다.
- isListEnd가 true여도 렌더링을 계속하여 시도하는 문제
  -> isListEnd가 true이면 intersect 요소를 렌더링하지 않도록 변경하여 해결하였습니다.
- 친구 목록에서 intersection이 먼저 일어나면 요청 목록이 친구 목록을 뒤집어씌워서 친구 목록을 확인할 수 없게 되는 문제
  -> isListEnd의 초기값을 true로 설정하고, 요청 목록을 불러온 뒤 isListEnd를 false로 변경해 intersection이 발생하도록 하여 해결하였습니다.
- 친구 목록이 개발자 도구 등으로 가려져있을 경우 intersection threshold가 커서 fetch가 일어나지 않는 문제
  -> 이런 경우를 고려하여 threshold 값을 감소시켜주었습니다.

## 테스트 (Optional)

API 연동 테스트 완료

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE

fix #83
