### PR TITLE
Feat: ChatMessage component 제작

### DIFF
--- a/src/components/atoms/Avatar/Avatar.tsx
+++ b/src/components/atoms/Avatar/Avatar.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import MaterialAvatar from '@material-ui/core/Avatar';
 
+type StyleProps = { isClickable: boolean };
+
 const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
     margin: theme.spacing(1),
+    cursor: ({ isClickable }: StyleProps) => (isClickable ? 'pointer' : 'inherit'),
+    '&:hover': {
+      opacity: ({ isClickable }: StyleProps) => (isClickable ? '0.5' : '1.0'),
+      transition: 'all 0.2s',
+    },
   },
   small: {
     width: theme.spacing(3),
@@ -21,27 +28,32 @@ const useStyles = makeStyles((theme: Theme) => createStyles({
 }));
 
 type AvatarProps = {
+  className?: string,
   src?: string,
   alt: string,
   size?: 'small' | 'medium' | 'large',
+  onClick?: React.MouseEventHandler,
 };
 
 const Avatar = ({
-  src, alt, size,
+  className, src, alt, size, onClick,
 } : AvatarProps) => {
-  const classes = useStyles();
+  const classes = useStyles({ isClickable: onClick !== null });
   return (
     <MaterialAvatar
-      className={`${classes.root} ${classes[size!]}`}
+      className={`${classes.root} ${classes[size!]} ${className}`}
       src={src}
       alt={alt}
+      onClick={onClick}
     />
   );
 };
 
 Avatar.defaultProps = {
+  className: '',
   src: '',
   size: 'medium',
+  onClick: null,
 };
 
 export default Avatar;

--- a/src/components/organisms/ChatMessage/ChatMessage.stories.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.stories.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { Meta } from '@storybook/react';
+import Grid from '@material-ui/core/Grid/Grid';
+import { UserInfoType } from '../../../types/User';
+import { MessageType } from '../../../types/Chat';
+import List from '../../atoms/List/List';
+import { ContextProvider } from '../../../utils/hooks/useContext';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+import Typo from '../../atoms/Typo/Typo';
+import ChatMessage from './ChatMessage';
+import Dialog from '../../molecules/Dialog/Dialog';
+import useDialog, { DialogProps } from '../../../utils/hooks/useDialog';
+
+export default {
+  title: 'organisms/ChatMessage',
+  component: ChatMessage,
+} as Meta;
+
+const shortMessage: MessageType & { user: UserInfoType } = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+  content: 'Lorem ipsum dolor sit amet',
+  createdAt: new Date(),
+  user: {
+    id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+    name: 'USERNAME',
+    avatar: '',
+    status: 'OFFLINE',
+  },
+};
+
+const longMessage: MessageType & { user: UserInfoType } = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+  content: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+  createdAt: new Date(),
+  user: {
+    id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+    name: 'USERNAME',
+    avatar: '',
+    status: 'OFFLINE',
+  },
+};
+
+export const Default = () => (
+  <>
+    <Typo variant="h5" gutterBottom align="center">OWNER</Typo>
+    <Grid container>
+      <ChatMessage
+        info={{ ...shortMessage, user: { ...shortMessage.user, name: 'OWNER' } }}
+        userRole="OWNER"
+        setOpen={() => {}}
+        setDialog={() => {}}
+      />
+    </Grid>
+    <Typo variant="h5" gutterBottom align="center">ADMIN</Typo>
+    <Grid container>
+      <ChatMessage
+        info={{ ...longMessage, user: { ...longMessage.user, name: 'ADMIN' } }}
+        userRole="ADMIN"
+        setOpen={() => {}}
+        setDialog={() => {}}
+      />
+    </Grid>
+    <Typo variant="h5" gutterBottom align="center">MEMBER</Typo>
+    <Grid container>
+      <ChatMessage
+        info={{ ...longMessage, user: { ...longMessage.user, name: 'MEMBER' } }}
+        userRole="MEMBER"
+        setOpen={() => {}}
+        setDialog={() => {}}
+      />
+    </Grid>
+    <Typo variant="h5" gutterBottom align="center">ME</Typo>
+    <Grid container>
+      <ChatMessage
+        info={longMessage}
+        userRole="OWNER"
+        setOpen={() => {}}
+        setDialog={() => {}}
+        me
+      />
+    </Grid>
+  </>
+);
+
+type WithListProps = {
+  // eslint-disable-next-line no-unused-vars
+  setOpen: (value: boolean) => void,
+  // eslint-disable-next-line no-unused-vars
+  setDialog: (value: DialogProps) => void,
+};
+
+export const WithList = ({ setOpen, setDialog }: WithListProps) => (
+  <List height="78vh" scroll reverse>
+    <ChatMessage
+      info={shortMessage}
+      userRole="MEMBER"
+      setOpen={setOpen}
+      setDialog={setDialog}
+    />
+    <ChatMessage
+      info={{ ...shortMessage, user: { ...shortMessage.user, name: 'OWNER' } }}
+      userRole="OWNER"
+      setOpen={setOpen}
+      setDialog={setDialog}
+    />
+    <ChatMessage
+      info={shortMessage}
+      userRole="ADMIN"
+      setOpen={setOpen}
+      setDialog={setDialog}
+      me
+    />
+    <ChatMessage
+      info={{ ...longMessage, user: { ...longMessage.user, name: 'ADMIN' } }}
+      userRole="ADMIN"
+      setOpen={setOpen}
+      setDialog={setDialog}
+    />
+    <ChatMessage
+      info={shortMessage}
+      userRole="OWNER"
+      setOpen={setOpen}
+      setDialog={setDialog}
+      me
+    />
+    <ChatMessage
+      info={longMessage}
+      userRole="OWNER"
+      setOpen={setOpen}
+      setDialog={setDialog}
+      me
+    />
+    <ChatMessage
+      info={{ ...longMessage, user: { ...longMessage.user, name: 'MEMBER' } }}
+      userRole="MEMBER"
+      setOpen={setOpen}
+      setDialog={setDialog}
+    />
+  </List>
+);
+
+WithList.args = {
+  setOpen: () => {},
+  setDialog: () => {},
+};
+
+export const WithMainTemplate = () => {
+  const {
+    isOpen, setOpen, dialog, setDialog,
+  } = useDialog();
+  return (
+    <BrowserRouter>
+      <ContextProvider>
+        <Dialog
+          title={dialog.title}
+          content={dialog.content}
+          buttons={dialog.buttons}
+          isOpen={isOpen}
+          onClose={dialog.onClose}
+        />
+        <MainTemplate
+          main={(
+            <>
+              <Typo variant="h3" gutterBottom>Chat Test Page</Typo>
+              <Typo variant="h5">List</Typo>
+              <List />
+              <Typo variant="h5">List</Typo>
+              <List height="35vh" />
+            </>
+          )}
+          chat={<WithList setOpen={setOpen} setDialog={setDialog} />}
+        />
+      </ContextProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -87,7 +87,7 @@ const ChatMessage = ({
           overlap="circular"
           badgeContent={['ADMIN', 'OWNER'].includes(userRole) ? (
             <SecurityRoundedIcon
-              color="primary"
+              color={userRole === 'OWNER' ? 'secondary' : 'primary'}
               fontSize="small"
             />
           ) : <></>}

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import Badge from '@material-ui/core/Badge';
+import Grid from '@material-ui/core/Grid';
+import SecurityRoundedIcon from '@material-ui/icons/SecurityRounded';
+import { makeStyles } from '@material-ui/core/styles';
+import { MessageType } from '../../../types/Chat';
+import { UserInfoType } from '../../../types/User';
+import Avatar from '../../atoms/Avatar/Avatar';
+import Typo from '../../atoms/Typo/Typo';
+import { DialogProps } from '../../../utils/hooks/useDialog';
+
+type StyleProps = { me: boolean };
+
+const useStyles = makeStyles({
+  chat: {
+    marginBottom: ({ me }: StyleProps) => (me ? '1em' : ''),
+  },
+  message: {
+    wordBreak: 'break-all',
+    maxWidth: '70%',
+    padding: '10px',
+    boxShadow: '0px 0px 5px lightgray',
+    backgroundColor: ({ me }: StyleProps) => (me ? 'gray' : 'white'),
+    color: ({ me }: StyleProps) => (me ? 'white' : 'black'),
+    borderRadius: ({ me }: StyleProps) => (me ? '15px 15px 0 15px' : '15px 15px 15px 0'),
+  },
+  date: {
+    color: '#bbb',
+  },
+  name: {
+    margin: '8px 0 0 3px',
+  },
+  avatar: {
+    margin: '0 8px 0 0 !important',
+  },
+});
+
+type ChatProps = {
+  info: MessageType & { user: UserInfoType }, // FIXME type 고쳐야 합니다
+  userRole: 'OWNER' | 'ADMIN' | 'MEMBER',
+  me?: boolean,
+  // eslint-disable-next-line no-unused-vars
+  setOpen: (value: boolean) => void,
+  // eslint-disable-next-line no-unused-vars
+  setDialog: (value: DialogProps) => void,
+};
+
+const makeDateString = (date: Date) => {
+  const now = new Date();
+  const today = `${now.getFullYear()}.${now.getMonth() + 1}.${now.getDate()}`;
+  const messageDate = `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()}`;
+  if (today === messageDate) return `${date.getHours()}:${date.getMinutes()}`;
+  return `${messageDate} ${date.getHours()}:${date.getMinutes()}`;
+};
+
+const ChatMessage = ({
+  info, userRole, me = false, setOpen, setDialog,
+}: ChatProps) => {
+  const { user } = info;
+  const classes = useStyles({ me });
+  const handleClick = () => {
+    setDialog({
+      title: 'Menu',
+      content: 'temp chat menu',
+      onClose: () => setOpen(false),
+    }); // FIXME 유저 메뉴 고쳐야 합니다
+    setOpen(true);
+  };
+
+  return (
+    <Grid
+      item
+      container
+      className={classes.chat}
+      direction="column"
+      alignItems={me ? 'flex-end' : 'flex-start'}
+      justifyContent="flex-end"
+    >
+      <Grid item container justifyContent={me ? 'flex-end' : 'flex-start'} alignItems="flex-end">
+        {!me && (
+        <Badge
+          style={{ marginBottom: '0' }}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'left',
+          }}
+          overlap="circular"
+          badgeContent={['ADMIN', 'OWNER'].includes(userRole) ? (
+            <SecurityRoundedIcon
+              color="primary"
+              fontSize="small"
+            />
+          ) : <></>}
+        >
+          <Avatar
+            onClick={handleClick}
+            className={classes.avatar}
+            src={user.avatar}
+            alt={user.name}
+          />
+        </Badge>
+        )}
+        <div className={classes.message}>
+          <Typo>{info.content}</Typo>
+          <Typo className={classes.date} align={me ? 'left' : 'right'} variant="subtitle2">
+            {makeDateString(info.createdAt)}
+          </Typo>
+        </div>
+      </Grid>
+      <Grid item container justifyContent={me ? 'flex-end' : 'space-between'}>
+        {!me && <Typo className={classes.name} variant="body2">{user.name}</Typo>}
+      </Grid>
+    </Grid>
+  );
+};
+
+ChatMessage.defaultProps = {
+  me: false,
+};
+
+export default ChatMessage;

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,0 +1,5 @@
+export type MessageType = {
+  id: string,
+  content: string,
+  createdAt: Date,
+}; // FIXME: fix된 타입과 통합해야 합니다


### PR DESCRIPTION
## 기능에 대한 설명
채팅 UI에서 말풍선으로 사용할 수 있는 ChatMessage 컴포넌트를 제작하였습니다.
- Avatar에 onClick 속성을 추가하고, onClick props가 존재하는 경우 hover시 Avatar의 opacity가 변경되도록 하였습니다.
- 유저 정보를 기반으로 말풍선, Avatar, name, 메시지를 보낸 시간(createdAt)을 렌더링합니다.
  - me 속성이 있으면 Avatar, name을 그리지 않습니다.
  - userRole이 OWNER나 ADMIN이면 Badge를 렌더링합니다.

API가 확정되지 않은 상태이므로 Draft PR으로 올립니다!

### 질문
- 왕관 모양 [Material Icon](https://material-ui.com/components/material-icons/#material-icons)이 존재하지 않아 임의로 shield icon을 채택해 보았는데 어떤지 의견 부탁드립니다! 저도 이게 썩 마음에 들지는 않는데 이게 좋겠다 싶은 걸 못 찾겠더라고요...

## 테스트 (Optional)
- [x] Storybook으로 렌더링 확인

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE

close #86