### PR TITLE
Feat: ChannelListItem 제작

### DIFF
--- a/src/components/organisms/ChannelListItem/ChannelListItem.stories.tsx
+++ b/src/components/organisms/ChannelListItem/ChannelListItem.stories.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import ChannelListItem, { ChannelListItemSkeleton } from './ChannelListItem';
+import List from '../../atoms/List/List';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+import { ContextProvider } from '../../../utils/hooks/useContext';
+
+export default {
+  title: 'organisms/ChannelListItem',
+  component: ChannelListItem,
+} as Meta;
+
+export const Default = () => {
+  const role = 'NONE';
+
+  return (
+    <ChannelListItem
+      name="채팅하실분"
+      role={role}
+      unreads={0}
+      isLocked
+      updatedAt={new Date()}
+    />
+  );
+};
+
+export const SkeletonChannel = () => (
+  <ChannelListItemSkeleton />
+);
+
+export const WithList = () => {
+  const role0 = 'NONE';
+  const role1 = 'MEMBER';
+  const role2 = 'ADMIN';
+  const role3 = 'OWNER';
+
+  return (
+    <List scroll height="70vh">
+      <ChannelListItem
+        name="친구들만 와라"
+        isLocked
+        role={role0}
+        unreads={1}
+        updatedAt={new Date()}
+      />
+      <ChannelListItem
+        name="아무나 이야기 나눠요! ADMIN 어디갔냐 빨리다시들어와"
+        isLocked={false}
+        role={role2}
+        unreads={5}
+        updatedAt={new Date()}
+      />
+      <ChannelListItem
+        name="내가 만든 비밀 채널방"
+        isLocked
+        role={role3}
+        unreads={0}
+        updatedAt={new Date()}
+      />
+      <ChannelListItem
+        name="공개 채팅하실분 빨리 가입 고고"
+        isLocked={false}
+        role={role1}
+        unreads={11}
+        updatedAt={new Date()}
+      />
+      <ChannelListItem
+        name="내가 만든 공개 채팅방"
+        isLocked={false}
+        role={role3}
+        unreads={0}
+        updatedAt={new Date()}
+      />
+      <ChannelListItem
+        name="Ykoh님의 비공개채팅"
+        isLocked
+        role={role0}
+        unreads={1}
+        updatedAt={new Date()}
+      />
+      <ChannelListItem
+        name="Ykoh님의 공개채팅"
+        isLocked
+        role={role0}
+        unreads={1}
+        updatedAt={new Date()}
+      />
+    </List>
+  );
+};
+
+export const WithTemplate = () => (
+
+  <BrowserRouter>
+    <ContextProvider>
+      <MainTemplate
+        main={<WithList />}
+        chat={<h1>Chat</h1>}
+      />
+    </ContextProvider>
+  </BrowserRouter>
+);

--- a/src/components/organisms/ChannelListItem/ChannelListItem.stories.tsx
+++ b/src/components/organisms/ChannelListItem/ChannelListItem.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
 import ChannelListItem, { ChannelListItemSkeleton } from './ChannelListItem';
+import { ChannelType } from '../../../types/Chat';
 import List from '../../atoms/List/List';
 import MainTemplate from '../../templates/MainTemplate/MainTemplate';
 import { ContextProvider } from '../../../utils/hooks/useContext';
@@ -12,15 +13,19 @@ export default {
 } as Meta;
 
 export const Default = () => {
-  const role = 'NONE';
+  const channelInfo0: ChannelType = {
+    name: '채팅 할 사람~',
+    role: 'NONE',
+    unreads: 0,
+    isLocked: true,
+    updatedAt: new Date(),
+  };
 
   return (
     <ChannelListItem
-      name="채팅하실분"
-      role={role}
-      unreads={0}
-      isLocked
-      updatedAt={new Date()}
+      info={channelInfo0}
+      setOpen={() => {}}
+      setDialog={() => {}}
     />
   );
 };
@@ -30,61 +35,111 @@ export const SkeletonChannel = () => (
 );
 
 export const WithList = () => {
-  const role0 = 'NONE';
-  const role1 = 'MEMBER';
-  const role2 = 'ADMIN';
-  const role3 = 'OWNER';
+  const channelInfo1: ChannelType = {
+    name: '내가 만든 공개방',
+    role: 'OWNER',
+    unreads: 10,
+    isLocked: false,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo2: ChannelType = {
+    name: '내가 ADMIN인 공개방',
+    role: 'ADMIN',
+    unreads: 5,
+    isLocked: false,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo3: ChannelType = {
+    name: '내가 만든 비공개방',
+    role: 'OWNER',
+    unreads: 42,
+    isLocked: true,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo4: ChannelType = {
+    name: '내가 ADMIN인 비공개방',
+    role: 'ADMIN',
+    unreads: 2,
+    isLocked: true,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo5: ChannelType = {
+    name: '내가 멤버인 공개방',
+    role: 'MEMBER',
+    unreads: 0,
+    isLocked: false,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo6: ChannelType = {
+    name: '내가 멤버인 비공개방',
+    role: 'MEMBER',
+    unreads: 10,
+    isLocked: true,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo7: ChannelType = {
+    name: '아직 join이 안된 공개방',
+    role: 'NONE',
+    unreads: 0,
+    isLocked: false,
+    updatedAt: new Date(),
+  };
+
+  const channelInfo8: ChannelType = {
+    name: '아직 join이 안된 비공개방',
+    role: 'NONE',
+    unreads: 0,
+    isLocked: true,
+    updatedAt: new Date(),
+  };
 
   return (
     <List scroll height="70vh">
       <ChannelListItem
-        name="친구들만 와라"
-        isLocked
-        role={role0}
-        unreads={1}
-        updatedAt={new Date()}
+        info={channelInfo1}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
       <ChannelListItem
-        name="아무나 이야기 나눠요! ADMIN 어디갔냐 빨리다시들어와"
-        isLocked={false}
-        role={role2}
-        unreads={5}
-        updatedAt={new Date()}
+        info={channelInfo2}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
       <ChannelListItem
-        name="내가 만든 비밀 채널방"
-        isLocked
-        role={role3}
-        unreads={0}
-        updatedAt={new Date()}
+        info={channelInfo3}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
       <ChannelListItem
-        name="공개 채팅하실분 빨리 가입 고고"
-        isLocked={false}
-        role={role1}
-        unreads={11}
-        updatedAt={new Date()}
+        info={channelInfo4}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
       <ChannelListItem
-        name="내가 만든 공개 채팅방"
-        isLocked={false}
-        role={role3}
-        unreads={0}
-        updatedAt={new Date()}
+        info={channelInfo5}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
       <ChannelListItem
-        name="Ykoh님의 비공개채팅"
-        isLocked
-        role={role0}
-        unreads={1}
-        updatedAt={new Date()}
+        info={channelInfo6}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
       <ChannelListItem
-        name="Ykoh님의 공개채팅"
-        isLocked
-        role={role0}
-        unreads={1}
-        updatedAt={new Date()}
+        info={channelInfo7}
+        setOpen={() => {}}
+        setDialog={() => {}}
+      />
+      <ChannelListItem
+        info={channelInfo8}
+        setOpen={() => {}}
+        setDialog={() => {}}
       />
     </List>
   );

--- a/src/components/organisms/ChannelListItem/ChannelListItem.tsx
+++ b/src/components/organisms/ChannelListItem/ChannelListItem.tsx
@@ -34,11 +34,6 @@ const useStyles = makeStyles({
   skeleton: {
     animation: '$loading 1.8s infinite ease-in-out',
   },
-  skeletonCard: {
-    padding: '0.2em',
-    width: '100%',
-    height: '60px',
-  },
   skeletonIcon: {
     width: '36px',
     height: '36px',
@@ -62,7 +57,7 @@ export const ChannelListItemSkeleton = () => {
   const classes = useStyles();
   return (
     <ListItem>
-      <Grid className={`${classes.skeletonCard} ${classes.skeleton}`} item container justifyContent="space-around" alignItems="center">
+      <Grid className={`${classes.root}`} item container justifyContent="space-around" alignItems="center">
         <Grid item container justifyContent="center" alignItems="center" xs={2}>
           <div className={`${classes.skeletonTypo} ${classes.skeleton}`}> </div>
         </Grid>

--- a/src/components/organisms/ChannelListItem/ChannelListItem.tsx
+++ b/src/components/organisms/ChannelListItem/ChannelListItem.tsx
@@ -4,8 +4,9 @@ import { makeStyles } from '@material-ui/core/styles';
 import LockIcon from '@material-ui/icons/Lock';
 import Badge from '@material-ui/core/Badge';
 import Typo from '../../atoms/Typo/Typo';
+import { DialogProps } from '../../../utils/hooks/useDialog';
 import ListItem from '../../atoms/ListItem/ListItem';
-import { ChannelType } from '../../../types/Chat';
+import { MembershipRole, ChannelType } from '../../../types/Chat';
 import Button from '../../atoms/Button/Button';
 
 const useStyles = makeStyles({
@@ -67,7 +68,7 @@ export const ChannelListItemSkeleton = () => {
         <Grid item container justifyContent="center" alignItems="center" xs={1}>
           <div className={`${classes.skeletonIcon} ${classes.skeleton}`}> </div>
         </Grid>
-        <Grid item container justifyContent="center" alignItems="center" xs={4}>
+        <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
           <div className={`${classes.skeletonButton} ${classes.skeleton}`}> </div>
         </Grid>
       </Grid>
@@ -75,38 +76,39 @@ export const ChannelListItemSkeleton = () => {
   );
 };
 
-type ChannelListItemProps = ChannelType;
+// FIXME: API구현되고 나서 Dialog, setOpen 구현하기
+type ChannelListItemProps = {
+  info: ChannelType,
+  // eslint-disable-next-line no-unused-vars
+  setOpen: (value: boolean) => void,
+  // eslint-disable-next-line no-unused-vars
+  setDialog: (value: DialogProps) => void,
+};
 
 const makeDateString = (date: Date) => `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
 
 const ChannelListItem = ({
-  name, role, unreads, isLocked, updatedAt,
+  // eslint-disable-next-line no-unused-vars
+  info, setOpen, setDialog,
 }: ChannelListItemProps) => {
+  const {
+    name, role, unreads, isLocked, updatedAt,
+  } = info;
   const dateStr = makeDateString(updatedAt);
   const classes = useStyles();
-  const JoinButton = () => (<Button onClick={() => {}}>Join</Button>);
-  const ManageButton = () => (<Button onClick={() => {}}>Manage</Button>);
-  const OpenButton = () => (<Button onClick={() => {}}>Open</Button>);
+  const JoinButton = () => (<Button variant="outlined" onClick={() => {}}>채널 가입</Button>);
+  const ManageButton = () => (<Button variant="outlined" onClick={() => {}}>채널 관리</Button>);
+  const GoChatButton = () => (<Button variant="outlined" onClick={() => {}}>채팅 참가</Button>);
 
-  const Buttons = (opt: 'OWNER' | 'ADMIN' | 'MEMBER' | 'NONE') => {
+  const Buttons = (opt: MembershipRole) => {
     switch (opt) {
       case 'MEMBER':
         return (
           <Grid item>
-            <OpenButton />
+            <GoChatButton />
           </Grid>
         );
       case 'OWNER':
-        return (
-          <>
-            <Grid item>
-              <ManageButton />
-            </Grid>
-            <Grid item>
-              <OpenButton />
-            </Grid>
-          </>
-        );
       case 'ADMIN':
         return (
           <>
@@ -114,10 +116,11 @@ const ChannelListItem = ({
               <ManageButton />
             </Grid>
             <Grid item>
-              <OpenButton />
+              <GoChatButton />
             </Grid>
           </>
         );
+      case 'NONE':
       default:
         return (<JoinButton />);
     }
@@ -138,7 +141,7 @@ const ChannelListItem = ({
         <Grid item container justifyContent="center" alignItems="center" xs={1}>
           { isLocked ? <LockIcon fontSize="medium" /> : undefined }
         </Grid>
-        <Grid item container justifyContent="center" alignItems="center" xs={4}>
+        <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
           { Buttons(role) }
         </Grid>
       </Grid>

--- a/src/components/organisms/ChannelListItem/ChannelListItem.tsx
+++ b/src/components/organisms/ChannelListItem/ChannelListItem.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+import LockIcon from '@material-ui/icons/Lock';
+import Badge from '@material-ui/core/Badge';
+import Typo from '../../atoms/Typo/Typo';
+import ListItem from '../../atoms/ListItem/ListItem';
+import { ChannelType } from '../../../types/Chat';
+import Button from '../../atoms/Button/Button';
+
+const useStyles = makeStyles({
+  root: {
+    padding: '0.2em',
+    width: '100%',
+    height: '60px',
+  },
+  button: {
+    width: '6.5em',
+  },
+  badgeMargin: {
+    marginLeft: '1em',
+  },
+  '@keyframes loading': {
+    '0%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.1)',
+    },
+    '50%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.3)',
+    },
+    '100%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.1)',
+    },
+  },
+  skeleton: {
+    animation: '$loading 1.8s infinite ease-in-out',
+  },
+  skeletonCard: {
+    padding: '0.2em',
+    width: '100%',
+    height: '60px',
+  },
+  skeletonIcon: {
+    width: '36px',
+    height: '36px',
+    borderRadius: '18px',
+  },
+  skeletonTypo: {
+    margin: '5px',
+    width: '90%',
+    height: '30px',
+  },
+  skeletonButton: {
+    margin: '0.25em',
+    padding: '5px 15px',
+    borderRadius: '4px',
+    width: '61px',
+    height: '26px',
+  },
+});
+
+export const ChannelListItemSkeleton = () => {
+  const classes = useStyles();
+  return (
+    <ListItem>
+      <Grid className={`${classes.skeletonCard} ${classes.skeleton}`} item container justifyContent="space-around" alignItems="center">
+        <Grid item container justifyContent="center" alignItems="center" xs={2}>
+          <div className={`${classes.skeletonTypo} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={5}>
+          <div className={`${classes.skeletonTypo} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={1}>
+          <div className={`${classes.skeletonIcon} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={4}>
+          <div className={`${classes.skeletonButton} ${classes.skeleton}`}> </div>
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+};
+
+type ChannelListItemProps = ChannelType;
+
+const makeDateString = (date: Date) => `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
+
+const ChannelListItem = ({
+  name, role, unreads, isLocked, updatedAt,
+}: ChannelListItemProps) => {
+  const dateStr = makeDateString(updatedAt);
+  const classes = useStyles();
+  const JoinButton = () => (<Button onClick={() => {}}>Join</Button>);
+  const ManageButton = () => (<Button onClick={() => {}}>Manage</Button>);
+  const OpenButton = () => (<Button onClick={() => {}}>Open</Button>);
+
+  const Buttons = (opt: 'OWNER' | 'ADMIN' | 'MEMBER' | 'NONE') => {
+    switch (opt) {
+      case 'MEMBER':
+        return (
+          <Grid item>
+            <OpenButton />
+          </Grid>
+        );
+      case 'OWNER':
+        return (
+          <>
+            <Grid item>
+              <ManageButton />
+            </Grid>
+            <Grid item>
+              <OpenButton />
+            </Grid>
+          </>
+        );
+      case 'ADMIN':
+        return (
+          <>
+            <Grid item>
+              <ManageButton />
+            </Grid>
+            <Grid item>
+              <OpenButton />
+            </Grid>
+          </>
+        );
+      default:
+        return (<JoinButton />);
+    }
+  };
+
+  return (
+    <ListItem>
+      <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
+        <Grid item container justifyContent="center" alignItems="center" xs={2}>
+          <Typo variant="body1">{dateStr}</Typo>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={5}>
+          <Typo variant="h6">{name}</Typo>
+          {unreads && (role !== 'NONE') ? (
+            <Badge color="secondary" badgeContent={unreads} max={9} className={classes.badgeMargin} />
+          ) : null}
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={1}>
+          { isLocked ? <LockIcon fontSize="medium" /> : undefined }
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={4}>
+          { Buttons(role) }
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+};
+
+export default ChannelListItem;

--- a/src/types/Channel.ts
+++ b/src/types/Channel.ts
@@ -1,0 +1,1 @@
+export type MembershipRole = 'ADMIN' | 'OWNER' | 'MEMBER' | 'NONE';

--- a/src/types/Channel.ts
+++ b/src/types/Channel.ts
@@ -1,1 +1,0 @@
-export type MembershipRole = 'ADMIN' | 'OWNER' | 'MEMBER' | 'NONE';

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,5 +1,7 @@
 import { UserInfoType } from './User';
 
+export type MembershipRole = 'ADMIN' | 'OWNER' | 'MEMBER' | 'NONE';
+
 export type MessageType = { // 서버의 'message' 이벤트가 emit
   name: string, // channel이나 dm 상대의 name
   id: string, // message의 id
@@ -10,7 +12,7 @@ export type MessageType = { // 서버의 'message' 이벤트가 emit
 
 export type ChannelType = {
   name: string,
-  role: 'OWNER' | 'ADMIN' | 'MEMBER' | 'NONE',
+  role: MembershipRole,
   unreads: number,
   isLocked: boolean,
   updatedAt: Date,

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,0 +1,23 @@
+import { UserInfoType } from './User';
+
+export type MessageType = { // 서버의 'message' 이벤트가 emit
+  name: string, // channel이나 dm 상대의 name
+  id: string, // message의 id
+  content: string,
+  createdAt: Date,
+  user: UserInfoType, // 나 자신일 수도 있음
+}; // FIXME TEMP
+
+export type ChannelType = {
+  name: string,
+  role: 'OWNER' | 'ADMIN' | 'MEMBER' | 'NONE',
+  unreads: number,
+  isLocked: boolean,
+  updatedAt: Date,
+}; // FIXME TEMP
+
+export type DMRoomType = {
+  name: string,
+  latestMessage?: MessageType, // FIXME API 추가되면 구현
+  unreads: number,
+}; // FIXME TEMP


### PR DESCRIPTION
## 기능에 대한 설명

ChannelListItem 제작
- 입장한 방이면 ``unreads`` count가 보임
- ``admin``/``owner``면 채널 참가, 채널 관리 두 버튼이 보임
- skeleton UI 추가
- ``/type/Chat.ts`` 다른 브랜치에서 가져옴

### 질문
1. ``Channel`` 권한 관련 코드를 짜기 편하게 하기 위해 ``src/types/Chat.ts``에서 아무관계도 없는 ``NONE``을 추가했는 데, 이렇게 하지 말고 **FE**에서 정제한 다른 ``type``을 따로 만드는 게 나은 지 궁금합니다.
  - 또한 ``isLocked``라는 비밀번호 방인지 확인하는 ``type``을 넣었습니다. 비밀번호가 있으면 ``true``, 없으면 ``false``로 생각하고 코드를 작성했습니다.
2. ``ChannelListItem`` 가장 앞쪽에 ``updatedAt``을 넣었습니다. 나중에 업데이트 시간 순서대로 ``ChannelListItem``을 정렬하려고 하는 데, 어떻게 생각하시는 지 궁금합니다.
3. ``Buttons component``를 너무 하드코딩식으로 짰고 storybook의 코드도 너무 원시적으로 짰습니다. 이것을 개선할 때 어떻게 개선해야할 지 힌트 부탁드립니다. ㅠㅠ 뭔가 잘못되었다는 것은 알겠지만, 어떻게 개선해야할 지 혼자 고민을 너무 오래 하게 되어 @hyo-choi님의 혜안으로 보시고 알려주셨으면 좋겠습니다.
4. 그 외에도 API와 연결했을 때 미리 ``Dialog``를 연결하는 것, ``DMListItem``과의 공통적인 것을 어떻게 고려해야하는 지 궁금합니다.

## 테스트 (Optional)

- [ ] storybook 랜더링 확인
- [ ] API 구현에 맞춰 최종 완성

## REFERENCE (Optional)

[업적, 전적용 List component 제작 PR](https://github.com/404-DriverNotFound/frontend-b/pull/80/files)
[ProfileCard](https://github.com/404-DriverNotFound/frontend-b/tree/master/src/components/organisms/ProfileCard)

## ISSUE
close #85
