### PR TITLE
Feat: ChannelUserListItem component 제작

### DIFF
--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.stories.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.stories.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import ChannelUserListItem from './ChannelUserListItem';
+import List from '../../atoms/List/List';
 import { MemberType } from '../../../types/Chat';
+import { ContextProvider } from '../../../utils/hooks/useContext';
 
 export default {
   title: 'organisms/ChannelUserListItem',
@@ -13,7 +15,93 @@ const dummyUserListItem: MemberType = {
   name: 'USERNAME',
   avatar: '',
   status: 'ONLINE',
-  memberships: ['MEMBER', new Date(), null],
+  memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: null }],
 };
 
-export const Default = () => <ChannelUserListItem info={dummyUserListItem} myRole="OWNER" />;
+export const Default = () => (
+  <ContextProvider>
+    <ChannelUserListItem info={dummyUserListItem} myRole="OWNER" />
+  </ContextProvider>
+);
+
+export const IamOwnerWithList = () => (
+  <ContextProvider>
+    <List scroll height="70vh">
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'MutedMember',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'BannedMember',
+          status: 'IN_GAME',
+          memberships: [{ role: 'BANNED', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember',
+          status: 'OFFLINE',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'I am Admin',
+          memberships: [{ role: 'ADMIN', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
+    </List>
+  </ContextProvider>
+);
+
+export const IamAdminWithList = () => (
+  <ContextProvider>
+    <List scroll height="70vh">
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'MutedMember',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'BannedMember',
+          status: 'IN_GAME',
+          memberships: [{ role: 'BANNED', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember',
+          status: 'OFFLINE',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'I am OWNER',
+          memberships: [{ role: 'OWNER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
+    </List>
+  </ContextProvider>
+);

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.stories.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.stories.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
-import ChannelUserListItem from './ChannelUserListItem';
+import { BrowserRouter } from 'react-router-dom';
+import ChannelUserListItem, { ChannelUserListItemSkeleton } from './ChannelUserListItem';
 import List from '../../atoms/List/List';
 import { MemberType } from '../../../types/Chat';
 import { ContextProvider } from '../../../utils/hooks/useContext';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
 
 export default {
   title: 'organisms/ChannelUserListItem',
@@ -24,7 +26,9 @@ export const Default = () => (
   </ContextProvider>
 );
 
-export const IamOwnerWithList = () => (
+export const SkeletonChannel = () => <ChannelUserListItemSkeleton />;
+
+const IamOwnerWithList = () => (
   <ContextProvider>
     <List scroll height="70vh">
       <ChannelUserListItem
@@ -61,11 +65,37 @@ export const IamOwnerWithList = () => (
         }}
         myRole="OWNER"
       />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember1',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember2',
+          status: 'IN_GAME',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember3',
+          status: 'OFFLINE',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="OWNER"
+      />
     </List>
   </ContextProvider>
 );
 
-export const IamAdminWithList = () => (
+const IamAdminWithList = () => (
   <ContextProvider>
     <List scroll height="70vh">
       <ChannelUserListItem
@@ -88,7 +118,7 @@ export const IamAdminWithList = () => (
       <ChannelUserListItem
         info={{
           ...dummyUserListItem,
-          name: 'generalMember',
+          name: 'generalMember0',
           status: 'OFFLINE',
           memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
         }}
@@ -102,6 +132,54 @@ export const IamAdminWithList = () => (
         }}
         myRole="ADMIN"
       />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember1',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember2',
+          status: 'IN_GAME',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
+      <ChannelUserListItem
+        info={{
+          ...dummyUserListItem,
+          name: 'generalMember3',
+          status: 'OFFLINE',
+          memberships: [{ role: 'MEMBER', createdAt: new Date(), mutedAt: new Date() }],
+        }}
+        myRole="ADMIN"
+      />
     </List>
   </ContextProvider>
+);
+
+export const IamOwnerWithTemplate = () => (
+  <BrowserRouter>
+    <ContextProvider>
+      <MainTemplate
+        main={<IamOwnerWithList />}
+        chat={<h1>Chat</h1>}
+      />
+    </ContextProvider>
+  </BrowserRouter>
+);
+
+export const IamAdminWithTemplate = () => (
+  <BrowserRouter>
+    <ContextProvider>
+      <MainTemplate
+        main={<IamAdminWithList />}
+        chat={<h1>Chat</h1>}
+      />
+    </ContextProvider>
+  </BrowserRouter>
 );

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.stories.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import ChannelUserListItem from './ChannelUserListItem';
+import { MemberType } from '../../../types/Chat';
+
+export default {
+  title: 'organisms/ChannelUserListItem',
+  component: ChannelUserListItem,
+} as Meta;
+
+const dummyUserListItem: MemberType = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+  name: 'USERNAME',
+  avatar: '',
+  status: 'ONLINE',
+  memberships: ['MEMBER', new Date(), null],
+};
+
+export const Default = () => <ChannelUserListItem info={dummyUserListItem} myRole="OWNER" />;

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
@@ -2,16 +2,19 @@ import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import Badge from '@material-ui/core/Badge';
 import SecurityRoundedIcon from '@material-ui/icons/SecurityRounded';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, withStyles, createStyles } from '@material-ui/core/styles';
 import { useUserState } from '../../../utils/hooks/useContext';
 import ListItem from '../../atoms/ListItem/ListItem';
 import Typo from '../../atoms/Typo/Typo';
 import Avatar from '../../atoms/Avatar/Avatar';
-import { MemberType } from '../../../types/Chat';
+import { MembershipRole, MemberType } from '../../../types/Chat';
 import { UserStatusType } from '../../../types/User';
 import Button from '../../atoms/Button/Button';
 
-type StyleProps = { status: UserStatusType };
+type StyleProps = {
+  status: UserStatusType,
+  role: MembershipRole,
+};
 
 const useStyles = makeStyles({
   root: {
@@ -33,7 +36,30 @@ const useStyles = makeStyles({
       }
     },
   },
+  role: {
+    color: (props: StyleProps) => {
+      switch (props.role) {
+        case 'OWNER':
+          return 'red';
+        case 'ADMIN':
+          return 'blue';
+        case 'BANNED':
+          return 'gray';
+        case 'MEMBER':
+        case 'NONE':
+        default:
+          return 'black';
+      }
+    },
+  },
 });
+
+const StyledBadge = withStyles(() => createStyles({
+  badge: {
+    right: 18,
+    top: 18,
+  },
+}))(Badge);
 
 type ChannelUserListItemProps = {
   info: MemberType,
@@ -42,7 +68,7 @@ type ChannelUserListItemProps = {
 
 type ButtonObjType = {
   text: string,
-  variant: 'contained' | 'outlined' | 'text' | undefined,
+  variant: 'contained' | 'outlined' | 'text',
   onClick: React.MouseEventHandler,
 };
 
@@ -52,7 +78,7 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
   } = info;
   const { role, mutedAt } = memberships[0];
   const me = useUserState();
-  const classes = useStyles({ status });
+  const classes = useStyles({ status, role });
 
   if (me.id === id) return null;
 
@@ -75,40 +101,40 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
       case 'ADMIN':
         return '관리자';
       case 'BANNED':
-        return '강퇴된 유저';
+        return '차단된 유저';
       default:
         return '채팅 참여자';
     }
   };
 
-  const banButton: ButtonObjType = (() => {
+  const banButton = ((): ButtonObjType => {
     switch (role) {
       case 'BANNED':
         return {
-          text: '퇴장 해제',
+          text: '차단 해제',
           variant: 'contained',
           onClick: () => {}, // FIXME: onClick 구현
         };
       default:
         return {
-          text: '강제 퇴장',
+          text: '유저 차단',
           variant: 'outlined',
           onClick: () => {}, // FIXME: onClick 구현
         };
     }
   })();
 
-  const muteButton: ButtonObjType = (() => {
+  const muteButton = ((): ButtonObjType => {
     switch (mutedAt) {
       case null:
         return {
-          text: '임시 차단',
+          text: '유저 뮤트',
           variant: 'outlined',
           onClick: () => {}, // FIXME: onClick 구현
         };
       default:
         return {
-          text: '차단 해제',
+          text: '뮤트 해제',
           variant: 'contained',
           onClick: () => {}, // FIXME: onClick 구현
         };
@@ -116,7 +142,7 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
   })();
 
   // FIXME: 관리가 이미있는 데 요청되지 않도록하기
-  const adminButton: ButtonObjType = (() => {
+  const adminButton = ((): ButtonObjType => {
     switch (role) {
       case 'ADMIN':
         return {
@@ -158,7 +184,7 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
     <ListItem>
       <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
         <Grid item container justifyContent="center" alignItems="center" xs={1}>
-          <Badge
+          <StyledBadge
             style={{ marginBottom: '0' }}
             anchorOrigin={{
               vertical: 'top',
@@ -173,14 +199,14 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
             ) : <></>}
           >
             <Avatar src={avatar} alt={name} />
-          </Badge>
+          </StyledBadge>
         </Grid>
         <Grid item container justifyContent="center" alignItems="center" xs={2} direction="column">
           <Typo variant="h6">{name}</Typo>
           <Typo className={classes.status} variant="subtitle1">{makeStatusString()}</Typo>
         </Grid>
         <Grid item container justifyContent="center" alignItems="center" xs={1}>
-          <Typo variant="subtitle1">{makeRoleString()}</Typo>
+          <Typo variant="subtitle1" className={classes.role}>{makeRoleString()}</Typo>
         </Grid>
         <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
           {role === 'OWNER' ? null : Buttons}

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
+import Badge from '@material-ui/core/Badge';
+import SecurityRoundedIcon from '@material-ui/icons/SecurityRounded';
 import { makeStyles } from '@material-ui/core/styles';
 import { useUserState } from '../../../utils/hooks/useContext';
 import ListItem from '../../atoms/ListItem/ListItem';
@@ -47,8 +49,7 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
   const {
     id, name, avatar, status, memberships,
   } = info;
-  const role = memberships[0];
-  const mutedAt = memberships[2];
+  const { role, mutedAt } = memberships[0];
   const me = useUserState();
   const classes = useStyles({ status });
 
@@ -70,12 +71,12 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
     switch (role) {
       case 'BANNED':
         return {
-          text: '강제 퇴장',
+          text: '퇴장 해제',
           onClick: () => {}, // FIXME: onClick 구현
         };
       default:
         return {
-          text: '퇴장 해제',
+          text: '강제 퇴장',
           onClick: () => {}, // FIXME: onClick 구현
         };
     }
@@ -135,14 +136,30 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
     <ListItem>
       <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
         <Grid item container justifyContent="center" alignItems="center" xs={1}>
-          <Avatar src={avatar} alt={name} />
+          <Badge
+            style={{ marginBottom: '0' }}
+            anchorOrigin={{
+              vertical: 'top',
+              horizontal: 'left',
+            }}
+            overlap="circular"
+            badgeContent={['ADMIN', 'OWNER'].includes(role) ? (
+              <SecurityRoundedIcon
+                color={role === 'OWNER' ? 'secondary' : 'primary'}
+                fontSize="small"
+              />
+            ) : <></>}
+          >
+            <Avatar src={avatar} alt={name} />
+          </Badge>
         </Grid>
         <Grid item container justifyContent="center" alignItems="center" xs={2} direction="column">
           <Typo variant="h6">{name}</Typo>
           <Typo className={classes.status} variant="subtitle1">{makeStatusString()}</Typo>
         </Grid>
-        <Typo variant="subtitle1">{role}</Typo>
-        <Typo variant="subtitle1">{mutedAt}</Typo>
+        <Grid item container justifyContent="center" alignItems="center" xs={1}>
+          <Typo variant="subtitle1">{role}</Typo>
+        </Grid>
         <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
           {Buttons}
         </Grid>

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
@@ -42,6 +42,7 @@ type ChannelUserListItemProps = {
 
 type ButtonObjType = {
   text: string,
+  variant: 'contained' | 'outlined' | 'text' | undefined,
   onClick: React.MouseEventHandler,
 };
 
@@ -67,16 +68,31 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
     }
   };
 
+  const makeRoleString = (): string => {
+    switch (role) {
+      case 'OWNER':
+        return '채널 주인';
+      case 'ADMIN':
+        return '관리자';
+      case 'BANNED':
+        return '강퇴된 유저';
+      default:
+        return '채팅 참여자';
+    }
+  };
+
   const banButton: ButtonObjType = (() => {
     switch (role) {
       case 'BANNED':
         return {
           text: '퇴장 해제',
+          variant: 'contained',
           onClick: () => {}, // FIXME: onClick 구현
         };
       default:
         return {
           text: '강제 퇴장',
+          variant: 'outlined',
           onClick: () => {}, // FIXME: onClick 구현
         };
     }
@@ -87,11 +103,13 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
       case null:
         return {
           text: '임시 차단',
+          variant: 'outlined',
           onClick: () => {}, // FIXME: onClick 구현
         };
       default:
         return {
           text: '차단 해제',
+          variant: 'contained',
           onClick: () => {}, // FIXME: onClick 구현
         };
     }
@@ -103,11 +121,13 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
       case 'ADMIN':
         return {
           text: '관리 파직',
+          variant: 'contained',
           onClick: () => {}, // FIXME: onClick 구현
         };
       default:
         return {
           text: '관리 임명',
+          variant: 'outlined',
           onClick: () => {}, // FIXME: onClick 구현
         };
     }
@@ -115,6 +135,7 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
 
   const buttonArray = () => {
     const array: ButtonObjType[] = [];
+
     array.push(banButton);
     array.push(muteButton);
     if (myRole === 'OWNER') array.push(adminButton);
@@ -126,6 +147,7 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
       <Button
         onClick={button.onClick}
         key={button.text}
+        variant={button.variant}
       >
         {button.text}
       </Button>
@@ -158,10 +180,10 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
           <Typo className={classes.status} variant="subtitle1">{makeStatusString()}</Typo>
         </Grid>
         <Grid item container justifyContent="center" alignItems="center" xs={1}>
-          <Typo variant="subtitle1">{role}</Typo>
+          <Typo variant="subtitle1">{makeRoleString()}</Typo>
         </Grid>
         <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
-          {Buttons}
+          {role === 'OWNER' ? null : Buttons}
         </Grid>
       </Grid>
     </ListItem>

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
+import { useUserState } from '../../../utils/hooks/useContext';
+import ListItem from '../../atoms/ListItem/ListItem';
+import Typo from '../../atoms/Typo/Typo';
+import Avatar from '../../atoms/Avatar/Avatar';
+import { MemberType } from '../../../types/Chat';
+import { UserStatusType } from '../../../types/User';
+import Button from '../../atoms/Button/Button';
+
+type StyleProps = { status: UserStatusType };
+
+const useStyles = makeStyles({
+  root: {
+    padding: '0.2em',
+    width: '100%',
+    height: '60px',
+  },
+  status: {
+    color: (props: StyleProps) => {
+      switch (props.status) {
+        case 'ONLINE':
+          return 'lightgreen';
+        case 'OFFLINE':
+          return 'gray';
+        case 'IN_GAME':
+          return 'blue';
+        default:
+          return 'black';
+      }
+    },
+  },
+});
+
+type ChannelUserListItemProps = {
+  info: MemberType,
+  myRole: 'OWNER' | 'ADMIN',
+};
+
+type ButtonObjType = {
+  text: string,
+  onClick: React.MouseEventHandler,
+};
+
+const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
+  const {
+    id, name, avatar, status, memberships,
+  } = info;
+  const role = memberships[0];
+  const mutedAt = memberships[2];
+  const me = useUserState();
+  const classes = useStyles({ status });
+
+  if (me.id === id) return null;
+
+  const makeStatusString = (): string => {
+    switch (status) {
+      case 'ONLINE':
+      case 'OFFLINE':
+        return status;
+      case 'IN_GAME':
+        return '게임 중';
+      default:
+        return '';
+    }
+  };
+
+  const banButton: ButtonObjType = (() => {
+    switch (role) {
+      case 'BANNED':
+        return {
+          text: '강제 퇴장',
+          onClick: () => {}, // FIXME: onClick 구현
+        };
+      default:
+        return {
+          text: '퇴장 해제',
+          onClick: () => {}, // FIXME: onClick 구현
+        };
+    }
+  })();
+
+  const muteButton: ButtonObjType = (() => {
+    switch (mutedAt) {
+      case null:
+        return {
+          text: '임시 차단',
+          onClick: () => {}, // FIXME: onClick 구현
+        };
+      default:
+        return {
+          text: '차단 해제',
+          onClick: () => {}, // FIXME: onClick 구현
+        };
+    }
+  })();
+
+  // FIXME: 관리가 이미있는 데 요청되지 않도록하기
+  const adminButton: ButtonObjType = (() => {
+    switch (role) {
+      case 'ADMIN':
+        return {
+          text: '관리 파직',
+          onClick: () => {}, // FIXME: onClick 구현
+        };
+      default:
+        return {
+          text: '관리 임명',
+          onClick: () => {}, // FIXME: onClick 구현
+        };
+    }
+  })();
+
+  const buttonArray = () => {
+    const array: ButtonObjType[] = [];
+    array.push(banButton);
+    array.push(muteButton);
+    if (myRole === 'OWNER') array.push(adminButton);
+    return (array);
+  };
+
+  const Buttons = buttonArray().map((button) => (
+    <Grid item key={button.text}>
+      <Button
+        onClick={button.onClick}
+        key={button.text}
+      >
+        {button.text}
+      </Button>
+    </Grid>
+  ));
+
+  return (
+    <ListItem>
+      <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
+        <Grid item container justifyContent="center" alignItems="center" xs={1}>
+          <Avatar src={avatar} alt={name} />
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={2} direction="column">
+          <Typo variant="h6">{name}</Typo>
+          <Typo className={classes.status} variant="subtitle1">{makeStatusString()}</Typo>
+        </Grid>
+        <Typo variant="subtitle1">{role}</Typo>
+        <Typo variant="subtitle1">{mutedAt}</Typo>
+        <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
+          {Buttons}
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+};
+
+export default ChannelUserListItem;

--- a/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
+++ b/src/components/organisms/ChannelUserListItem/ChannelUserListItem.tsx
@@ -54,6 +54,80 @@ const useStyles = makeStyles({
   },
 });
 
+const useSkeletonStyles = makeStyles({
+  root: {
+    padding: '0.2em',
+    width: '100%',
+    height: '60px',
+  },
+  '@keyframes loading': {
+    '0%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.1)',
+    },
+    '50%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.3)',
+    },
+    '100%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.1)',
+    },
+  },
+  skeleton: {
+    animation: '$loading 1.8s infinite ease-in-out',
+  },
+  skeletonIcon: {
+    width: '36px',
+    height: '36px',
+    borderRadius: '18px',
+  },
+  skeletonName: {
+    margin: '5px',
+    width: '80%',
+    height: '25px',
+  },
+  skeletonStatus: {
+    margin: '5px',
+    width: '35%',
+    height: '18px',
+  },
+  skeletonRole: {
+    margin: '5px',
+    width: '100%',
+    height: '20px',
+  },
+  skeletonButton: {
+    margin: '0.25em',
+    padding: '5px 15px',
+    borderRadius: '4px',
+    width: '55px',
+    height: '25px',
+  },
+});
+
+export const ChannelUserListItemSkeleton = () => {
+  const classes = useSkeletonStyles();
+  return (
+    <ListItem>
+      <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
+        <Grid item container justifyContent="center" alignItems="center" xs={1}>
+          <div className={`${classes.skeletonIcon} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={2} direction="column">
+          <div className={`${classes.skeletonName} ${classes.skeleton}`}> </div>
+          <div className={`${classes.skeletonStatus} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={2}>
+          <div className={`${classes.skeletonRole} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>
+          <div className={`${classes.skeletonButton} ${classes.skeleton}`}> </div>
+          <div className={`${classes.skeletonButton} ${classes.skeleton}`}> </div>
+          <div className={`${classes.skeletonButton} ${classes.skeleton}`}> </div>
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+};
+
 const StyledBadge = withStyles(() => createStyles({
   badge: {
     right: 18,
@@ -161,7 +235,6 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
 
   const buttonArray = () => {
     const array: ButtonObjType[] = [];
-
     array.push(banButton);
     array.push(muteButton);
     if (myRole === 'OWNER') array.push(adminButton);
@@ -201,11 +274,11 @@ const ChannelUserListItem = ({ info, myRole }: ChannelUserListItemProps) => {
             <Avatar src={avatar} alt={name} />
           </StyledBadge>
         </Grid>
-        <Grid item container justifyContent="center" alignItems="center" xs={2} direction="column">
+        <Grid item container justifyContent="center" alignItems="center" xs={3} direction="column">
           <Typo variant="h6">{name}</Typo>
           <Typo className={classes.status} variant="subtitle1">{makeStatusString()}</Typo>
         </Grid>
-        <Grid item container justifyContent="center" alignItems="center" xs={1}>
+        <Grid item container justifyContent="center" alignItems="center" xs={2}>
           <Typo variant="subtitle1" className={classes.role}>{makeRoleString()}</Typo>
         </Grid>
         <Grid item container justifyContent="flex-end" alignItems="center" xs={4}>

--- a/src/types/Chat.ts
+++ b/src/types/Chat.ts
@@ -1,6 +1,6 @@
 import { UserInfoType } from './User';
 
-export type MembershipRole = 'ADMIN' | 'OWNER' | 'MEMBER' | 'NONE';
+export type MembershipRole = 'ADMIN' | 'OWNER' | 'MEMBER' | 'NONE' | 'BANNED';
 
 export type RawChannelType = {
   id: string,
@@ -30,3 +30,11 @@ export type DMRoomType = UserInfoType & {
   latestMessage: MessageType, // FIXME API 추가되면 구현
   unreads: number,
 }; // FIXME TEMP
+
+type MembershipType = {
+  role: MembershipRole,
+  createdAt: Date,
+  mutedAt: Date | null,
+};
+
+export type MemberType = UserInfoType & { memberships: MembershipType[] };


### PR DESCRIPTION
## 기능에 대한 설명

ChannelPage의 Channel User List에 사용될 ChannelUserListItem component를 제작했습니다.
OWNER와 ADMIN은 각각 허용된 권한을 가지고 ChannelUserList를 볼 수 있으며 허용된 권한에 따라 ChannelUserListItem component가 버튼들을 다르게 구성해줍니다.

> NOTE: 이 component에서 새롭게 추가된 props인 myRole은 상위 component에서 가공 후 넘겨줘야합니다.

## 테스트 (Optional)

- [x] Storybook으로 랜더링 확인
  - [x] Channel User의 정보가 필요한 만큼 담겨있는 가?
    - [x] 해당 User의 Avatar, name, status 등
  - [x] 멤버 관리 버튼이 올바르게 구성되어 있는 가?
    - [x] 내가 OWNER일 경우 해당 User를 관리임명/관리파직, 유저차단/차단해제, 유저뮤트/뮤트해제로 관리 할 수 있는 가?
    - [x] 내가 ADMIN일 경우 해당 User를 유저차단/차단해제, 유저뮤트/뮤트해제로 관리할 수 있는 가?

## REFERENCE (Optional)

[DMListItem](https://github.com/404-DriverNotFound/frontend-b/pull/91)

## ISSUE

close #95
