### PR TITLE
Feat: PlayerProfile component 제작

### DIFF
--- a/src/components/organisms/PlayerProfile/PlayerProfile.stories.tsx
+++ b/src/components/organisms/PlayerProfile/PlayerProfile.stories.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import PlayerProfile, { UserGameInfoType } from './PlayerProfile';
+import ContextProvider from '../../../utils/hooks/useContext';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+import Typo from '../../atoms/Typo/Typo';
+
+export default {
+  title: 'organisms/PlayerProfile',
+  component: PlayerProfile,
+} as Meta;
+
+const dummyUserGameInfo: UserGameInfoType = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+  name: 'USERNAME',
+  avatar: '',
+  status: 'OFFLINE',
+  win: 0,
+  lose: 0,
+};
+
+const jikangGameInfo: UserGameInfoType = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+  name: 'Jikang',
+  avatar: 'https://cdn.intra.42.fr/users/medium_jikang.jpg',
+  status: 'IN_GAME',
+  win: 4,
+  lose: 2,
+};
+
+const fakeUserGameInfo: UserGameInfoType = {
+  id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+  name: 'ABCDEFGHIJK',
+  avatar: 'https://cdn.intra.42.fr/users/medium_default.png',
+  status: 'IN_GAME',
+  win: 40,
+  lose: 20,
+};
+
+const useStyles = makeStyles({
+  div: {
+    backgroundColor: 'lightgray',
+    width: '100%',
+    height: '100%',
+  },
+  gameScreen: {
+    backgroundColor: 'lightgray',
+    width: '100%',
+    height: '58vh',
+  },
+});
+
+export const Default = () => (
+  <Grid item container justifyContent="space-between" alignItems="center" xs={10}>
+    <PlayerProfile userGameInfo={dummyUserGameInfo} />
+  </Grid>
+);
+
+export const WithMainTemplate = () => {
+  const classes = useStyles();
+
+  return (
+    <BrowserRouter>
+      <ContextProvider>
+        <MainTemplate
+          main={(
+            <Grid item container justifyContent="space-around" alignItems="center">
+              <Grid item container justifyContent="center" alignItems="center" xs={12}>
+                <Typo variant="h5">Classic Mode</Typo>
+              </Grid>
+              <Grid item container justifyContent="center" alignItems="center" xs={10}>
+                <div className={classes.gameScreen}>game. 게임 화면</div>
+              </Grid>
+              <Grid item container justifyContent="space-between" alignItems="center" xs={10}>
+                <PlayerProfile userGameInfo={jikangGameInfo} />
+                <Typo variant="h5">VS</Typo>
+                <PlayerProfile userGameInfo={fakeUserGameInfo} />
+              </Grid>
+            </Grid>
+          )}
+          chat={<div className={classes.div}>chat. 배경색은 스토리에서 적용한 것입니다!</div>}
+        />
+      </ContextProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/components/organisms/PlayerProfile/PlayerProfile.tsx
+++ b/src/components/organisms/PlayerProfile/PlayerProfile.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import ListItem from '../../atoms/ListItem/ListItem';
+import { UserInfoType } from '../../../types/User';
+import Avatar from '../../atoms/Avatar/Avatar';
+import Typo from '../../atoms/Typo/Typo';
+
+// FIXME: 임시 Type 작성
+export type UserGameInfoType = UserInfoType & { win: number, lose: number };
+
+type PlayerProfileProps = {
+  userGameInfo: UserGameInfoType,
+};
+
+const useStyles = makeStyles({
+  root: {
+    padding: '0.2em',
+    width: '13vw',
+    height: '100%',
+  },
+});
+
+const PlayerProfile = ({ userGameInfo }: PlayerProfileProps) => {
+  const {
+    name, avatar, win, lose,
+  } = userGameInfo;
+  const classes = useStyles();
+
+  const makeMatchHistoryString = (): string => (`전적 ${win}승 ${lose}패`);
+
+  return (
+    <ListItem>
+      <Grid className={classes.root} item container justifyContent="center" alignItems="center">
+        <Grid item container justifyContent="center" alignItems="center" xs={12}>
+          <Avatar src={avatar} alt={name} />
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={12}>
+          <Typo variant="body1">{name}</Typo>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={12}>
+          <Typo variant="body2">
+            {makeMatchHistoryString()}
+          </Typo>
+        </Grid>
+      </Grid>
+    </ListItem>
+  );
+};
+
+export default PlayerProfile;


### PR DESCRIPTION
## 기능에 대한 설명

GamePlayPage에서 Player의 아이디, 아바타, 전적을 알 수있도록 하는 Card를 만들었습니다.
ListItem으로 만들어져있고, UserInfoType에 win, lose의 property를 추가하여 [UserGameInfoType](https://github.com/404-DriverNotFound/frontend-b/compare/feat/component-PlayerProfile%2378?expand=1#diff-02527bcb476ee07f0519909437359ae42f9f1d5b6854a4521f82f185a3be6b2aR10)를 임시로 만들었습니다. 나중에 API가 완성되면 이에 따라 수정이 필요할 것같습니다.

## 테스트 (Optional)

- Storybook으로 랜더링 확인

## REFERENCE (Optional)

.

## ISSUE

close #78 
