### PR TITLE
Feat: GamePage component 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { DMToMessage, messageToMessage } from './utils/chats';
 import ChannelManagePage from './components/pages/ChannelManagePage/ChannelManagePage';
 import DMPage from './components/pages/DMPage/DMPage';
 import { RawUserInfoType } from './types/Response';
+import GamePage from './components/pages/GamePage/GamePage';
 
 const useStyles = makeStyles({
   progress: {
@@ -185,6 +186,7 @@ const App = () => {
               <Route exact path="/">
                 <Redirect to="/game" />
               </Route>
+              <Route path="/game" component={GamePage} />
               <Route path="/community" component={CommunityPage} />
               <Route path="/channel/manage/:channelName" component={ChannelManagePage} />
               <Route path="/channel" component={ChannelPage} />

--- a/src/components/molecules/GameOptionCard/GameOptionCard.tsx
+++ b/src/components/molecules/GameOptionCard/GameOptionCard.tsx
@@ -12,14 +12,11 @@ const useStyles = makeStyles({
     height: '35vh',
     '&:hover': { color: '#208fea' },
   },
-  cardActionMargin: {
-    marginTop: '1em',
-  },
   image: {
     width: '100%',
     height: '15vh',
     objectFit: 'contain',
-    paddingTop: '2em',
+    paddingTop: '3em',
     filter: 'opacity(.5) drop-shadow(0 0 0 blue)',
     '&::-webkit-filter': 'opacity(.5) drop-shadow(0 0 0 blue)',
   },
@@ -114,7 +111,7 @@ const GameOptionCard = ({ option, onClick } : GameOptionCardProps) => {
   };
 
   return (
-    <CardActionArea onClick={onClick} className={classes.cardActionMargin}>
+    <CardActionArea onClick={onClick}>
       <Card className={classes.card}>
         { ChooseOption(option) }
       </Card>

--- a/src/components/pages/GamePage/GamePage.stories.tsx
+++ b/src/components/pages/GamePage/GamePage.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import GamePage from './GamePage';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+import ContextProvider from '../../../utils/hooks/useContext';
+
+export default {
+  title: 'Pages/GamePage',
+  component: GamePage,
+} as Meta;
+
+const useStyles = makeStyles({
+  div: {
+    backgroundColor: 'lightgray',
+    width: '100%',
+    height: '100%',
+  },
+});
+
+export const WithMainTemplate = () => {
+  const classes = useStyles();
+
+  return (
+    <BrowserRouter>
+      <ContextProvider>
+        <MainTemplate
+          main={<GamePage />}
+          chat={<div className={classes.div}>chat. 배경색은 스토리에서 적용한 것입니다!</div>}
+        />
+      </ContextProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
+import {
+  Route, Switch, useHistory, Redirect,
+} from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import GameOptionCard from '../../molecules/GameOptionCard/GameOptionCard';
+
+const MAIN_GAME_PAGE = '/game';
+const CLASSIC_PLAY_PATH = '/game/playclassic';
+const SPEED_PLAY_PATH = '/game/playspeed';
+const REVERSE_PLAY_PATH = '/game/playreverse';
+const WATCH_PLAY_PATH = '/game/watch';
 
 const useStyles = makeStyles({
   root: {
@@ -13,25 +22,41 @@ const useStyles = makeStyles({
   },
 });
 
-const GamePage = () => {
+const GameMainPage = () => {
+  const history = useHistory();
   const classes = useStyles();
 
   return (
     <Grid className={classes.root} container justifyContent="center" alignItems="center" spacing={1}>
       <Grid item xs={6}>
-        <GameOptionCard option="classic" onClick={() => {}} />
+        <GameOptionCard option="classic" onClick={() => { history.push(CLASSIC_PLAY_PATH); }} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="speed" onClick={() => {}} />
+        <GameOptionCard option="speed" onClick={() => { history.push(SPEED_PLAY_PATH); }} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="reverse" onClick={() => {}} />
+        <GameOptionCard option="reverse" onClick={() => { history.push(REVERSE_PLAY_PATH); }} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="watch" onClick={() => {}} />
+        <GameOptionCard option="watch" onClick={() => { history.push(WATCH_PLAY_PATH); }} />
       </Grid>
     </Grid>
   );
 };
+
+const GamePage = () => (
+  <>
+    <Switch>
+      <Route exact path={MAIN_GAME_PAGE} component={GameMainPage} />
+      <Route exact path={CLASSIC_PLAY_PATH} render={() => <h1>Classic play</h1>} />
+      <Route exact path={SPEED_PLAY_PATH} render={() => <h1>Speedy play</h1>} />
+      <Route exact path={REVERSE_PLAY_PATH} render={() => <h1>Reverse play</h1>} />
+      <Route exact path={WATCH_PLAY_PATH} render={() => <h1>Watch play</h1>} />
+      <Route path="/">
+        <Redirect to={MAIN_GAME_PAGE} />
+      </Route>
+    </Switch>
+  </>
+);
 
 export default GamePage;

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import GameOptionCard from '../../molecules/GameOptionCard/GameOptionCard';
+
+const useStyles = makeStyles({
+  root: {
+    height: '78vh',
+    margin: '0.5em auto',
+    backgroundColor: '#eee',
+    borderRadius: '10px',
+    padding: '5px 5px 1em 5px',
+  },
+});
+
+const GamePage = () => {
+  const classes = useStyles();
+
+  return (
+    <Grid className={classes.root} container justifyContent="center" alignItems="center" spacing={1}>
+      <Grid item xs={6}>
+        <GameOptionCard option="classic" onClick={() => {}} />
+      </Grid>
+      <Grid item xs={6}>
+        <GameOptionCard option="speed" onClick={() => {}} />
+      </Grid>
+      <Grid item xs={6}>
+        <GameOptionCard option="reverse" onClick={() => {}} />
+      </Grid>
+      <Grid item xs={6}>
+        <GameOptionCard option="watch" onClick={() => {}} />
+      </Grid>
+    </Grid>
+  );
+};
+
+export default GamePage;

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -18,7 +18,8 @@ const useStyles = makeStyles({
     margin: '0.5em auto',
     backgroundColor: '#eee',
     borderRadius: '10px',
-    padding: '5px 5px 1em 5px',
+    padding: '5px',
+    // padding: '0px 5px 1em 5px',
   },
 });
 
@@ -27,7 +28,7 @@ const GameMainPage = () => {
   const classes = useStyles();
 
   return (
-    <Grid className={classes.root} container justifyContent="center" alignItems="center" spacing={1}>
+    <Grid className={classes.root} container justifyContent="space-evenly" alignItems="center" spacing={3}>
       <Grid item xs={6}>
         <GameOptionCard option="classic" onClick={() => { history.push(CLASSIC_PLAY_PATH); }} />
       </Grid>

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -19,7 +19,6 @@ const useStyles = makeStyles({
     backgroundColor: '#eee',
     borderRadius: '10px',
     padding: '5px',
-    // padding: '0px 5px 1em 5px',
   },
 });
 


### PR DESCRIPTION

<img width="1273" alt="스크린샷 2021-09-15 오후 7 41 57" src="https://user-images.githubusercontent.com/59194905/133419385-d4b780f5-77c5-4188-be51-9121ec02a289.png">

## 기능에 대한 설명

GamePage에서 Main이 되는 Page를 제작했습니다. 유저가 Classic Game, Speed Game, Reverse Game, WatchGame을 선택해서 해당 페이지에 접속할 수 있도록 GameOptionCard를 정리해서 넣었습니다.

현재 Classic Game, Speed Game, Reverse Game, WatchGame들이 완성되지 않았으므로 임시로 랜더링하도록 했습니다.
예시: `<Route exact path={CLASSIC_PLAY_PATH} render={() => <h1>Classic play</h1>} />`

CommunityPage, ChannelPage과의 통일성을 위해 흰색 바탕안에 GameOptionCard를 넣었습니다.

## 테스트 (Optional)

- [x] App 동작 테스트
- [x] Storybook 랜더링 확인

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE

close #29 
