### PR TITLE
[Feat] GameWatchPage component 제작

### DIFF
--- a/src/components/organisms/GameListItem/GameListItem.stories.tsx
+++ b/src/components/organisms/GameListItem/GameListItem.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
-import GameListItem from './GameListItem';
+import GameListItem, { GameListItemSkeleton } from './GameListItem';
 import List from '../../atoms/List/List';
 import MainTemplate from '../../templates/MainTemplate/MainTemplate';
 import ContextProvider from '../../../utils/hooks/useContext';
@@ -54,6 +54,8 @@ const Speed = () => (
 );
 
 export const Default = () => <Normal />;
+
+export const SkeletonGameListItem = () => <GameListItemSkeleton />;
 
 export const WithList = () => (
   <List scroll height="15em">

--- a/src/components/organisms/GameListItem/GameListItem.stories.tsx
+++ b/src/components/organisms/GameListItem/GameListItem.stories.tsx
@@ -30,7 +30,7 @@ const Normal = () => (
   <GameListItem
     leftUser={userFirst}
     rightUser={userSecond}
-    mode="classic"
+    mode="CLASSIC"
     onClick={() => {}}
   />
 );
@@ -39,7 +39,7 @@ const Reverse = () => (
   <GameListItem
     leftUser={userSecond}
     rightUser={userFirst}
-    mode="reverse"
+    mode="REVERSE"
     onClick={() => {}}
   />
 );
@@ -48,7 +48,7 @@ const Speed = () => (
   <GameListItem
     leftUser={userFirst}
     rightUser={userSecond}
-    mode="speed"
+    mode="SPEED"
     onClick={() => {}}
   />
 );

--- a/src/components/organisms/GameListItem/GameListItem.tsx
+++ b/src/components/organisms/GameListItem/GameListItem.tsx
@@ -31,7 +31,69 @@ const useStyles = makeStyles({
     filter: 'opacity(.5) drop-shadow(0 0 0 yellow)',
     '&::-webkit-filter': 'opacity(.5) drop-shadow(0 0 0 yellow)',
   },
+  '@keyframes loading': {
+    '0%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.1)',
+    },
+    '50%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.3)',
+    },
+    '100%': {
+      backgroundColor: 'rgba(165, 165, 165, 0.1)',
+    },
+  },
+  skeleton: {
+    animation: '$loading 1.8s infinite ease-in-out',
+  },
+  skeletonIcon: {
+    width: '36px',
+    height: '36px',
+    borderRadius: '18px',
+  },
+  skeletonAvatar: {
+    width: '40px',
+    height: '40px',
+    borderRadius: '20px',
+  },
+  skeletonName: {
+    margin: '5px',
+    width: '40%',
+    height: '25px',
+  },
+  skeletonVersus: {
+    margin: '5px',
+    width: '20%',
+    height: '25px',
+  },
 });
+
+export const GameListItemSkeleton = () => {
+  const classes = useStyles();
+  return (
+    <ListClickItem onClick={() => {}}>
+      <Grid className={classes.root} item container justifyContent="space-around" alignItems="center">
+        <Grid item container justifyContent="flex-end" alignItems="center" xs={1} spacing={1}>
+          <div className={`${classes.skeletonIcon} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="flex-end" alignItems="center" xs={4} spacing={1}>
+          <div className={`${classes.skeletonName} ${classes.skeleton}`}> </div>
+          <Grid item container justifyContent="center" alignItems="center" xs={4} spacing={1}>
+            <div className={`${classes.skeletonAvatar} ${classes.skeleton}`}> </div>
+          </Grid>
+        </Grid>
+        <Grid item container justifyContent="center" alignItems="center" xs={2}>
+          <div className={`${classes.skeletonVersus} ${classes.skeleton}`}> </div>
+        </Grid>
+        <Grid item container justifyContent="flex-start" alignItems="center" xs={4} spacing={1}>
+          <Grid item container justifyContent="center" alignItems="center" xs={4} spacing={1}>
+            <div className={`${classes.skeletonAvatar} ${classes.skeleton}`}> </div>
+          </Grid>
+          <div className={`${classes.skeletonName} ${classes.skeleton}`}> </div>
+        </Grid>
+      </Grid>
+    </ListClickItem>
+  );
+};
 
 type GameListItemProps = {
   leftUser: UserInfoType,

--- a/src/components/organisms/GameListItem/GameListItem.tsx
+++ b/src/components/organisms/GameListItem/GameListItem.tsx
@@ -62,7 +62,7 @@ const useStyles = makeStyles({
   },
   skeletonVersus: {
     margin: '5px',
-    width: '20%',
+    width: '13%',
     height: '25px',
   },
 });

--- a/src/components/organisms/GameListItem/GameListItem.tsx
+++ b/src/components/organisms/GameListItem/GameListItem.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typo from '../../atoms/Typo/Typo';
 import { UserInfoType } from '../../../types/User';
+import { GameModeType } from '../../../types/Match';
 import Avatar from '../../atoms/Avatar/Avatar';
 import ListClickItem from '../../atoms/ListClickItem/ListClickItem';
 
@@ -32,8 +33,6 @@ const useStyles = makeStyles({
   },
 });
 
-type GameModeType = 'classic' | 'speed' | 'reverse';
-
 type GameListItemProps = {
   leftUser: UserInfoType,
   rightUser: UserInfoType,
@@ -47,19 +46,19 @@ const GameListItem = ({
   const classes = useStyles();
   const makeIcon = () => {
     switch (mode) {
-      case 'speed':
+      case 'SPEED':
         return (
           <Tooltip arrow title="Speed Mode">
             <img src="/images/fast.png" alt="Speed Mode" className={`${classes.image} ${classes.speed}`} />
           </Tooltip>
         );
-      case 'reverse':
+      case 'REVERSE':
         return (
           <Tooltip arrow title="Reverse Mode">
             <img src="/images/reverse.png" alt="Reverse Mode" className={`${classes.image} ${classes.reverse}`} />
           </Tooltip>
         );
-      case 'classic':
+      case 'CLASSIC':
       default:
         return (
           <Tooltip arrow title="Classic Mode">

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -5,12 +5,13 @@ import {
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import GameOptionCard from '../../molecules/GameOptionCard/GameOptionCard';
+import GameWatchPage from '../GameWatchPage/GameWatchPage';
 
 const MAIN_GAME_PAGE = '/game';
 const CLASSIC_PLAY_PATH = '/game/playclassic';
 const SPEED_PLAY_PATH = '/game/playspeed';
 const REVERSE_PLAY_PATH = '/game/playreverse';
-export const WATCH_PLAY_PATH = '/game/watch';
+const WATCH_PLAY_PATH = '/game/watch';
 
 const useStyles = makeStyles({
   root: {
@@ -51,7 +52,7 @@ const GamePage = () => (
       <Route exact path={CLASSIC_PLAY_PATH} render={() => <h1>Classic play</h1>} />
       <Route exact path={SPEED_PLAY_PATH} render={() => <h1>Speedy play</h1>} />
       <Route exact path={REVERSE_PLAY_PATH} render={() => <h1>Reverse play</h1>} />
-      <Route exact path={WATCH_PLAY_PATH} render={() => <h1>Watch play</h1>} />
+      <Route exact path={WATCH_PLAY_PATH} component={GameWatchPage} />
       <Route path="/">
         <Redirect to={MAIN_GAME_PAGE} />
       </Route>

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -52,8 +52,8 @@ const GamePage = () => (
       <Route exact path={CLASSIC_PLAY_PATH} render={() => <h1>Classic play</h1>} />
       <Route exact path={SPEED_PLAY_PATH} render={() => <h1>Speedy play</h1>} />
       <Route exact path={REVERSE_PLAY_PATH} render={() => <h1>Reverse play</h1>} />
-      <Route exact path={WATCH_PLAY_PATH} component={GameWatchPage} />
-      <Route path="/">
+      <Route path={WATCH_PLAY_PATH} component={GameWatchPage} />
+      <Route exact path="/">
         <Redirect to={MAIN_GAME_PAGE} />
       </Route>
     </Switch>

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -10,7 +10,7 @@ const MAIN_GAME_PAGE = '/game';
 const CLASSIC_PLAY_PATH = '/game/playclassic';
 const SPEED_PLAY_PATH = '/game/playspeed';
 const REVERSE_PLAY_PATH = '/game/playreverse';
-const WATCH_PLAY_PATH = '/game/watch';
+export const WATCH_PLAY_PATH = '/game/watch';
 
 const useStyles = makeStyles({
   root: {

--- a/src/components/pages/GameWatchPage/GameWatchPage.stories.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.stories.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter, Route } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import GameWatchPage from './GameWatchPage';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+// import { RawMatchType } from '../../../types/Match';
+import ContextProvider from '../../../utils/hooks/useContext';
+
+export default {
+  title: 'Pages/GameWatchPage',
+  component: GameWatchPage,
+} as Meta;
+
+const useStyles = makeStyles({
+  div: {
+    backgroundColor: 'lightgray',
+    width: '100%',
+    height: '100%',
+  },
+});
+
+// const SampleRawMatchType: RawMatchType = {
+//   id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+//   createdAt: String(new Date()),
+//   status: 'IN_PROGRESS',
+//   type: 'EXHIBITON',
+//   gameMode: 'CLASSIC',
+//   user1: {
+//     id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+//     name: 'LeftUsername',
+//     avatar: '',
+//     status: 'IN_GAME',
+//     enable2FA: false,
+//     authenticatorSecret: false,
+//     isSecondFactorAuthenticated: false,
+//     score: 4,
+//   },
+//   user2: {
+//     id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
+//     name: 'RightUsername',
+//     avatar: '',
+//     status: 'IN_GAME',
+//     enable2FA: false,
+//     authenticatorSecret: false,
+//     isSecondFactorAuthenticated: false,
+//     score: 2,
+//   },
+// };
+
+export const WithMainTemplate = () => {
+  const classes = useStyles();
+
+  return (
+    <BrowserRouter>
+      <ContextProvider>
+        <Route
+          path={['/game/watch', '/']}
+          render={() => (
+            <MainTemplate
+              main={<GameWatchPage />}
+              chat={<div className={classes.div}>chat. 배경색은 스토리에서 적용한 것입니다!</div>}
+            />
+          )}
+        />
+      </ContextProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/components/pages/GameWatchPage/GameWatchPage.stories.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.stories.tsx
@@ -4,7 +4,6 @@ import { BrowserRouter, Route } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import GameWatchPage from './GameWatchPage';
 import MainTemplate from '../../templates/MainTemplate/MainTemplate';
-// import { RawMatchType } from '../../../types/Match';
 import ContextProvider from '../../../utils/hooks/useContext';
 
 export default {
@@ -19,34 +18,6 @@ const useStyles = makeStyles({
     height: '100%',
   },
 });
-
-// const SampleRawMatchType: RawMatchType = {
-//   id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
-//   createdAt: String(new Date()),
-//   status: 'IN_PROGRESS',
-//   type: 'EXHIBITON',
-//   gameMode: 'CLASSIC',
-//   user1: {
-//     id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
-//     name: 'LeftUsername',
-//     avatar: '',
-//     status: 'IN_GAME',
-//     enable2FA: false,
-//     authenticatorSecret: false,
-//     isSecondFactorAuthenticated: false,
-//     score: 4,
-//   },
-//   user2: {
-//     id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
-//     name: 'RightUsername',
-//     avatar: '',
-//     status: 'IN_GAME',
-//     enable2FA: false,
-//     authenticatorSecret: false,
-//     isSecondFactorAuthenticated: false,
-//     score: 2,
-//   },
-// };
 
 export const WithMainTemplate = () => {
   const classes = useStyles();

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -77,7 +77,7 @@ const MatchList = ({ type }: ListProps) => {
           key={match.id}
           leftUser={match.user1}
           rightUser={match.user2}
-          mode={match.mode} // FIXME: 임시로 Classic으로 설정 API 수정 후 고치기
+          mode={match.mode}
           onClick={() => {}}
         />
       ))}

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import Grid from '@material-ui/core/Grid';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import { WATCH_PLAY_PATH } from '../GamePage/GamePage';
+import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
+import { RawMatchType, MatchType } from '../../../types/Match';
+import List from '../../atoms/List/List';
+import ListItem from '../../atoms/ListItem/ListItem';
+import SubMenu from '../../molecules/SubMenu/SubMenu';
+import useIntersect from '../../../utils/hooks/useIntersect';
+import GameListItem from '../../organisms/GameListItem/GameListItem';
+
+const ALL_MATCH_PATH = `${WATCH_PLAY_PATH}/all`;
+const LADDER_MATCH_PATH = `${WATCH_PLAY_PATH}/ladder`;
+const EXHIBITION_MATCH_PATH = `${WATCH_PLAY_PATH}/exhibition`;
+
+const COUNTS_PER_PAGE = 10;
+
+type ListProps = {
+  type: 'ALL' | 'LADDER' | 'EXHIBITION',
+}
+
+// type MatchListProps = {
+//   [index: string]: MatchGameType,
+// };
+
+// const matchTypes: MatchGameType = {
+//   all: '',
+//   ladder: 'LADDER',
+//   exhibition: 'EXHIBITION',
+// };
+
+// const useStyles = makeStyles({
+//   root: {
+//     height: '78vh',
+//     margin: '0.5em auto',
+//     backgroundColor: '#eee',
+//     borderRadius: '10px',
+//     padding: '5px',
+//   },
+// });
+
+const MatchList = ({ type }: ListProps) => {
+  const { CancelToken } = axios;
+  const source = CancelToken.source();
+  const path = type === 'ALL' ? makeAPIPath('/matches/spectating') : makeAPIPath(`/matches/spectating?type=${type}`);
+  // const matchType = matchTypes[type];
+  const [matches, setMatches] = useState<MatchType[]>([]);
+  const [isListEnd, setListEnd] = useState(true);
+  const [page, setPage] = useState<number>(0);
+
+  const fetchItems = () => {
+    if (isListEnd) return;
+
+    asyncGetRequest(`${path}?perPage=${COUNTS_PER_PAGE}&page=${page}`, source)
+      .then(({ data }: { data: RawMatchType[] }) => {
+        const typed: MatchType[] = data;
+        setMatches((prev) => prev.concat(typed.map((match) => ({ ...match, user1: { ...match.user1, avatar: makeAPIPath(`/${match.user1.avatar}`) }, user2: { ...match.user2, avatar: makeAPIPath(`/${match.user2.avatar}`) } }))));
+        if (data.length === 0 || data.length < COUNTS_PER_PAGE) setListEnd(true);
+      })
+      .catch((error) => {
+        source.cancel();
+        errorMessageHandler(error);
+        setListEnd(true);
+      });
+  };
+
+  useEffect(() => {
+    fetchItems();
+  }, [page]);
+
+  // eslint-disable-next-line no-unused-vars
+  const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
+    observer.unobserve(entry.target);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    setPage((prev) => prev + 1);
+    observer.observe(entry.target);
+  });
+
+  useEffect(() => {
+    setListEnd(false);
+
+    return () => {
+      source.cancel();
+      setMatches([]);
+      setListEnd(true);
+    };
+  }, []);
+
+  return (
+    <>
+      {matches.map((match) => (
+        <ListItem key={match.id}>
+          <GameListItem
+            leftUser={match.user1}
+            rightUser={match.user2}
+            mode={match.gameMode}
+            onClick={() => {}}
+          />
+        </ListItem>
+      ))}
+      {!isListEnd && (
+        <div
+          style={{ display: 'flex', justifyContent: 'center', marginTop: '4px' }}
+          ref={isListEnd ? null : setRef as React.LegacyRef<HTMLDivElement>}
+        >
+          <Grid
+            item
+            container
+            direction="column"
+            justifyContent="flex-start"
+            alignItems="stretch"
+            wrap="nowrap"
+            spacing={1}
+            xs={12}
+          >
+            <ListItem>a</ListItem>
+            <ListItem>b</ListItem>
+            <ListItem>c</ListItem>
+          </Grid>
+        </div>
+      )}
+    </>
+  );
+};
+
+const AllMatchList = () => <MatchList type="ALL" />;
+const LadderList = () => <MatchList type="LADDER" />;
+const ExhibitionList = () => <MatchList type="EXHIBITION" />;
+
+const list = [
+  { name: 'ALL', link: ALL_MATCH_PATH },
+  { name: 'LADDER', link: LADDER_MATCH_PATH },
+  { name: 'EXHIBITION', link: EXHIBITION_MATCH_PATH },
+];
+
+const GameWatchPage = () => (
+  <>
+    <SubMenu current={window.location.pathname} list={list} />
+    <List height="78vh" scroll>
+      <Switch>
+        <Route exact path={ALL_MATCH_PATH} component={AllMatchList} />
+        <Route exact path={LADDER_MATCH_PATH} component={LadderList} />
+        <Route exact path={EXHIBITION_MATCH_PATH} component={ExhibitionList} />
+        <Route path="/">
+          <Redirect to={ALL_MATCH_PATH} />
+        </Route>
+      </Switch>
+    </List>
+  </>
+);
+
+export default GameWatchPage;

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -10,7 +10,7 @@ import SubMenu from '../../molecules/SubMenu/SubMenu';
 import useIntersect from '../../../utils/hooks/useIntersect';
 import GameListItem from '../../organisms/GameListItem/GameListItem';
 
-const ALL_MATCH_PATH = '/game/watch/';
+const ALL_MATCH_PATH = '/game/watch/all';
 const LADDER_MATCH_PATH = '/game/watch/ladder';
 const EXHIBITION_MATCH_PATH = '/game/watch/exhibition';
 
@@ -23,8 +23,8 @@ type ListProps = {
 const MatchList = ({ type }: ListProps) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
-  const path = type === 'ALL' ? makeAPIPath('/matches/spectating') : makeAPIPath(`/matches/spectating?type=${type}`);
-  // const matchType = matchTypes[type];
+  const path = makeAPIPath('/matches/spectating');
+  const typePath = type === 'ALL' ? '' : `&type=${type}`;
   const [matches, setMatches] = useState<MatchType[]>([]);
   const [isListEnd, setListEnd] = useState(true);
   const [page, setPage] = useState<number>(0);
@@ -32,10 +32,14 @@ const MatchList = ({ type }: ListProps) => {
   const fetchItems = () => {
     if (isListEnd) return;
 
-    asyncGetRequest(`${path}?perPage=${COUNTS_PER_PAGE}&page=${page}`, source)
+    asyncGetRequest(`${path}?perPage=${COUNTS_PER_PAGE}&page=${page}${typePath}`, source)
       .then(({ data }: { data: RawMatchType[] }) => {
         const typed: MatchType[] = data;
-        setMatches((prev) => prev.concat(typed.map((match) => ({ ...match, user1: { ...match.user1, avatar: makeAPIPath(`/${match.user1.avatar}`) }, user2: { ...match.user2, avatar: makeAPIPath(`/${match.user2.avatar}`) } }))));
+        setMatches((prev) => prev.concat(typed.map((match) => ({
+          ...match,
+          user1: { ...match.user1, avatar: makeAPIPath(`/${match.user1.avatar}`) },
+          user2: { ...match.user2, avatar: makeAPIPath(`/${match.user2.avatar}`) },
+        }))));
         if (data.length === 0 || data.length < COUNTS_PER_PAGE) setListEnd(true);
       })
       .catch((error) => {
@@ -70,14 +74,13 @@ const MatchList = ({ type }: ListProps) => {
   return (
     <>
       {matches.map((match) => (
-        <ListItem key={match.id}>
-          <GameListItem
-            leftUser={match.user1}
-            rightUser={match.user2}
-            mode="CLASSIC" // FIXME: 임시로 Classic으로 설정 API 수정 후 고치기
-            onClick={() => {}}
-          />
-        </ListItem>
+        <GameListItem
+          key={match.id}
+          leftUser={match.user1}
+          rightUser={match.user2}
+          mode="CLASSIC" // FIXME: 임시로 Classic으로 설정 API 수정 후 고치기
+          onClick={() => {}}
+        />
       ))}
       {!isListEnd && (
         <div

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -77,7 +77,7 @@ const MatchList = ({ type }: ListProps) => {
           key={match.id}
           leftUser={match.user1}
           rightUser={match.user2}
-          mode="CLASSIC" // FIXME: 임시로 Classic으로 설정 API 수정 후 고치기
+          mode={match.mode} // FIXME: 임시로 Classic으로 설정 API 수정 후 고치기
           onClick={() => {}}
         />
       ))}

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -5,10 +5,9 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
 import { RawMatchType, MatchType } from '../../../types/Match';
 import List from '../../atoms/List/List';
-import ListItem from '../../atoms/ListItem/ListItem';
 import SubMenu from '../../molecules/SubMenu/SubMenu';
 import useIntersect from '../../../utils/hooks/useIntersect';
-import GameListItem from '../../organisms/GameListItem/GameListItem';
+import GameListItem, { GameListItemSkeleton } from '../../organisms/GameListItem/GameListItem';
 
 const ALL_MATCH_PATH = '/game/watch/all';
 const LADDER_MATCH_PATH = '/game/watch/ladder';
@@ -97,9 +96,9 @@ const MatchList = ({ type }: ListProps) => {
             spacing={1}
             xs={12}
           >
-            <ListItem>a</ListItem>
-            <ListItem>b</ListItem>
-            <ListItem>c</ListItem>
+            <GameListItemSkeleton />
+            <GameListItemSkeleton />
+            <GameListItemSkeleton />
           </Grid>
         </div>
       )}

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import Grid from '@material-ui/core/Grid';
 import { Redirect, Route, Switch } from 'react-router-dom';
-import { WATCH_PLAY_PATH } from '../GamePage/GamePage';
 import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
 import { RawMatchType, MatchType } from '../../../types/Match';
 import List from '../../atoms/List/List';
@@ -11,35 +10,15 @@ import SubMenu from '../../molecules/SubMenu/SubMenu';
 import useIntersect from '../../../utils/hooks/useIntersect';
 import GameListItem from '../../organisms/GameListItem/GameListItem';
 
-const ALL_MATCH_PATH = `${WATCH_PLAY_PATH}/all`;
-const LADDER_MATCH_PATH = `${WATCH_PLAY_PATH}/ladder`;
-const EXHIBITION_MATCH_PATH = `${WATCH_PLAY_PATH}/exhibition`;
+const ALL_MATCH_PATH = '/game/watch/';
+const LADDER_MATCH_PATH = '/game/watch/ladder';
+const EXHIBITION_MATCH_PATH = '/game/watch/exhibition';
 
 const COUNTS_PER_PAGE = 10;
 
 type ListProps = {
   type: 'ALL' | 'LADDER' | 'EXHIBITION',
 }
-
-// type MatchListProps = {
-//   [index: string]: MatchGameType,
-// };
-
-// const matchTypes: MatchGameType = {
-//   all: '',
-//   ladder: 'LADDER',
-//   exhibition: 'EXHIBITION',
-// };
-
-// const useStyles = makeStyles({
-//   root: {
-//     height: '78vh',
-//     margin: '0.5em auto',
-//     backgroundColor: '#eee',
-//     borderRadius: '10px',
-//     padding: '5px',
-//   },
-// });
 
 const MatchList = ({ type }: ListProps) => {
   const { CancelToken } = axios;
@@ -95,7 +74,7 @@ const MatchList = ({ type }: ListProps) => {
           <GameListItem
             leftUser={match.user1}
             rightUser={match.user2}
-            mode={match.gameMode}
+            mode="CLASSIC" // FIXME: 임시로 Classic으로 설정 API 수정 후 고치기
             onClick={() => {}}
           />
         </ListItem>

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -11,7 +11,7 @@ export type RawMatchType = {
   createdAt: string,
   status: MatchStatusType,
   type: MatchGameType,
-  gameMode: GameModeType, // FIXME: API 수정 후 적용하기
+  // gameMode: GameModeType, // FIXME: API 수정 후 적용하기
   user1: RawUserInfoType & { score: number },
   user2: RawUserInfoType & { score: number },
 };
@@ -20,7 +20,7 @@ export type MatchType = {
   id: string,
   status: MatchStatusType, // FIXME: IN_PROGRESS만 받는 지 확인 후 삭제
   type: MatchGameType,
-  gameMode: GameModeType, // FIXME: API 수정 후 적용하기
+  // gameMode: GameModeType, // FIXME: API 수정 후 적용하기
   user1: RawUserInfoType & { score: number },
   user2: RawUserInfoType & { score: number },
 }

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -1,0 +1,26 @@
+import { RawUserInfoType } from './Response';
+
+export type MatchStatusType = 'IN_PROGRESS' | 'DONE';
+
+export type MatchGameType = 'LADDER' | 'EXHIBITON';
+
+export type GameModeType = 'CLASSIC' | 'SPEED' | 'REVERSE';
+
+export type RawMatchType = {
+  id: string,
+  createdAt: string,
+  status: MatchStatusType,
+  type: MatchGameType,
+  gameMode: GameModeType, // FIXME: API 수정 후 적용하기
+  user1: RawUserInfoType & { score: number },
+  user2: RawUserInfoType & { score: number },
+};
+
+export type MatchType = {
+  id: string,
+  status: MatchStatusType, // FIXME: IN_PROGRESS만 받는 지 확인 후 삭제
+  type: MatchGameType,
+  gameMode: GameModeType, // FIXME: API 수정 후 적용하기
+  user1: RawUserInfoType & { score: number },
+  user2: RawUserInfoType & { score: number },
+}

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -11,16 +11,16 @@ export type RawMatchType = {
   createdAt: string,
   status: MatchStatusType,
   type: MatchGameType,
-  // gameMode: GameModeType, // FIXME: API 수정 후 적용하기
+  mode: GameModeType,
   user1: RawUserInfoType & { score: number },
   user2: RawUserInfoType & { score: number },
 };
 
 export type MatchType = {
   id: string,
-  status: MatchStatusType, // FIXME: IN_PROGRESS만 받는 지 확인 후 삭제
+  status: MatchStatusType,
   type: MatchGameType,
-  // gameMode: GameModeType, // FIXME: API 수정 후 적용하기
+  mode: GameModeType,
   user1: RawUserInfoType & { score: number },
   user2: RawUserInfoType & { score: number },
 }

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -18,7 +18,6 @@ export type RawMatchType = {
 
 export type MatchType = {
   id: string,
-  status: MatchStatusType,
   type: MatchGameType,
   mode: GameModeType,
   user1: RawUserInfoType & { score: number },


### PR DESCRIPTION
## 기능에 대한 설명

현재 관전 가능한 게임 목록을 가져오는 GameWatchPage를 제작했습니다. GameListItem의 리스트를 All, Ladder, Exhibition에 따라서 보여줍니다. 

Pagination을 할 때 유저가 덜 지루하도록 GameListItem에 GameListItemSkeletonUI component를 추가했습니다!

### 구현되지 않은 항목들
- [x] GET /matches/spectating에서 mode type을 받아와서 GameListItem이 mode 구현
  - [x] 이 항목은 **BE**에 [issue](https://github.com/404-DriverNotFound/backend-b/issues/94)로 해당 API의 프로퍼티에 추가 요청 후 적용되었습니다
- 관전을 위해 GameListItem을 클릭했을 때 이미 게임이 끝난 경우에 어떤 식으로 경고 메시지 또는 안내 메시지를 보낼 지에 대해서는 고려 안되어 있습니다.
  - 이 점은 게임을 구현하고 나서 어떻게 이 점을 해결할 지 결정해야하는 부분일 것같습니다.

## 테스트 (Optional)

- [x] APP 동작 테스트
- [x] Storybook으로 랜더링 확인

## REFERENCE (Optional)

[CommunityPage PR](https://github.com/404-DriverNotFound/frontend-b/pull/70)

## ISSUE

close #100 
