### PR TITLE
Fix: 2FA 회원가입 후 로그인이 되지 않는 문제 해결

### DIFF
--- a/src/components/pages/MFAPage/MFAPage.tsx
+++ b/src/components/pages/MFAPage/MFAPage.tsx
@@ -103,7 +103,9 @@ const MFAPage = () => {
             isSecondFactorAuthenticated,
           },
         });
-        history.replace('/');
+        appDispatch({ type: 'loading' });
+        history.push('/');
+        window.location.reload();
       })
       .catch((error) => {
         if (error.response) toast.error('인증 번호가 잘못되었습니다.');


### PR DESCRIPTION
## 기능에 대한 설명
본 PR은 @PennyBlack2008 님과 VSCode LiveShare로 함께 작업하였습니다.
2FA 인증이 되지 않은 상태에서도 App.tsx에서 /blocks에 GET 요청이 보내지고 있었는데 이 때 발생하는 403 Forbidden 에러로 인해 앱에서 로그아웃되어 로그인 로직이 동작하지 않았습니다.
2FA 인증이 되지 않은 유저는 /blocks 등에 GET 요청을 보내지 못하도록 하고, 인증 이후 앱을 새로 mount(reload)하여 문제를 해결하였습니다.

## 테스트 (Optional)
- [x] docker-compose로 API 연동 테스트

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE
fix #102
