### PR TITLE
Fix: 하나의 DM이 모든 DMList를 갱신하는 문제 해결

### DIFF
--- a/src/utils/hooks/useAppContext.tsx
+++ b/src/utils/hooks/useAppContext.tsx
@@ -61,9 +61,11 @@ const newMessageReducer = (state: AppStateType, message: MessageType): AppStateT
     });
   } else if (state.DMs.some((dmRoom) => dmRoom.name === message.name)) { // 기존 DM
     ret.DMs = state.DMs.map((dmRoom: DMRoomType) => {
-      if (dmRoom.name === message.name && dmRoom.name !== state.chatting?.name) {
-        return { ...dmRoom, unreads: dmRoom.unreads + 1, latestMessage: message };
-      } return { ...dmRoom, unreads: 0, latestMessage: message };
+      if (dmRoom.name === message.name) { // 나와 dm 상대방의 dm방에 도착한 dm
+        if (dmRoom.name !== state.chatting?.name) { // 열려있는 채팅일때
+          return { ...dmRoom, unreads: dmRoom.unreads + 1, latestMessage: message };
+        } return { ...dmRoom, unreads: 0, latestMessage: message }; // 열려있지 않은 채팅일때
+      } return { ...dmRoom };
     });
   } else { // 처음 받거나 보낸 DM
     let userInfo : UserInfoType | null = null;


### PR DESCRIPTION
## 기능에 대한 설명

하나의 DM이 모든 DMListItem을 갱신하는 문제를 해결했습니다.
상태 관리 로직에서 채팅 중인 방/채팅 중이 아닌 방/map에 해당되는 방의 case를 잘못 나누어서 발생한 문제였습니다.
map에 해당되지 않는 방은 현재 상태를 유지하도록 하고, map에 해당되는 방만 latestMessage를 갱신하도록 하여 해결하였습니다.

## 테스트 (Optional)

- [x] 갱신된 DMListItem만 올바르게 갱신 되는 것을 확인

## REFERENCE (Optional)

.

## ISSUE

fix #103
