### PR TITLE
Feat: ProfilePage 전적, 업적 리스트 구현

### DIFF
--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -30,11 +30,15 @@ const initialUserInfo: RelatedInfoType = {
   relationship: 'NONE',
 };
 
+type UserNameType = {
+  username: string,
+};
+
 type MatchParams = {
   username: string,
 };
 
-const MatchHistory = ({ username }: MatchParams) => {
+const MatchHistory = ({ username }: UserNameType) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
   const path = makeAPIPath(`/matches/${username}`);
@@ -121,7 +125,7 @@ const MatchHistory = ({ username }: MatchParams) => {
   );
 };
 
-const AchievementList = ({ username }: MatchParams) => {
+const AchievementList = ({ username }: UserNameType) => {
   const [Achieves, setAchieves] = useState<AchievementType[]>([]);
   const [isLoaded, setLoaded] = useState<boolean>(false);
   const path = makeAPIPath(`/users/${username}/achievements`);
@@ -212,7 +216,7 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
         buttons={dialog.buttons}
         onClose={dialog.onClose}
       />
-      <Grid container direction="column" spacing={6} justifyContent="space-evenly" alignItems="stretch">
+      <Grid container direction="column" spacing={4} justifyContent="space-evenly" alignItems="stretch">
         <Grid item>
           <ProfileCard
             userInfo={user}
@@ -224,13 +228,13 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
         </Grid>
         <Grid item>
           <Typo variant="h5">Match History</Typo>
-          <List height="15em" scroll>
+          <List height="23vh" scroll>
             <MatchHistory username={username} />
           </List>
         </Grid>
         <Grid item>
           <Typo variant="h5">Achievements</Typo>
-          <List height="15em" scroll>
+          <List height="23vh" scroll>
             <AchievementList username={username} />
           </List>
         </Grid>

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -34,15 +34,7 @@ type MatchParams = {
   username: string,
 };
 
-type MatchHistoryProps = {
-  username: string
-};
-
-type AchievementProps = {
-  username: string
-};
-
-const MatchHistory = ({ username }: MatchHistoryProps) => {
+const MatchHistory = ({ username }: MatchParams) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
   const path = makeAPIPath(`/matches/${username}`);
@@ -129,7 +121,7 @@ const MatchHistory = ({ username }: MatchHistoryProps) => {
   );
 };
 
-const AchievementList = ({ username }: AchievementProps) => {
+const AchievementList = ({ username }: MatchParams) => {
   const [Achieves, setAchieves] = useState<AchievementType[]>([]);
   const [isLoaded, setLoaded] = useState<boolean>(false);
   const path = makeAPIPath(`/achievements/${username}`);

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -126,12 +126,14 @@ const MatchHistory = ({ username }: UserNameType) => {
 };
 
 const AchievementList = ({ username }: UserNameType) => {
+  const { CancelToken } = axios;
+  const source = CancelToken.source();
   const [achieves, setAchieves] = useState<AchievementType[]>([]);
   const [isLoaded, setLoaded] = useState<boolean>(false);
   const path = makeAPIPath(`/users/${username}/achievements`);
 
   useEffect(() => {
-    axios.get(path)
+    axios.get(path, { cancelToken: source.token })
       .then((responses) => {
         const { data }: { data: RawAchievementType[] } = responses;
         const Achievements: AchievementType[] = data.map((achieve) => ({

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -124,7 +124,7 @@ const MatchHistory = ({ username }: MatchParams) => {
 const AchievementList = ({ username }: MatchParams) => {
   const [Achieves, setAchieves] = useState<AchievementType[]>([]);
   const [isLoaded, setLoaded] = useState<boolean>(false);
-  const path = makeAPIPath(`/achievements/${username}`);
+  const path = makeAPIPath(`/users/${username}/achievements`);
 
   useEffect(() => {
     axios.get(path)

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -22,10 +22,6 @@ import useIntersect from '../../../utils/hooks/useIntersect';
 
 const COUNTS_PER_PAGE = 10;
 
-type MatchParams = {
-  username: string,
-};
-
 const initialUserInfo: RelatedInfoType = {
   id: '',
   name: '',
@@ -34,11 +30,22 @@ const initialUserInfo: RelatedInfoType = {
   relationship: 'NONE',
 };
 
-const MatchHistory = () => {
+type MatchParams = {
+  username: string,
+};
+
+type MatchHistoryProps = {
+  username: string
+};
+
+type AchievementProps = {
+  username: string
+};
+
+const MatchHistory = ({ username }: MatchHistoryProps) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
-  const path = makeAPIPath('/matches/me');
-  const me = useUserState();
+  const path = makeAPIPath(`/matches/${username}`);
   const [matchHistories, setMatchHistories] = useState<MatchType[]>([]);
   const [isListEnd, setListEnd] = useState(true);
   const [page, setPage] = useState<number>(0);
@@ -46,7 +53,7 @@ const MatchHistory = () => {
   const fetchItems = () => {
     if (isListEnd) return;
 
-    asyncGetRequest(`${path}?status=DONE&perPage=${COUNTS_PER_PAGE}&page=${page}`, source)
+    asyncGetRequest(`${path}?perPage=${COUNTS_PER_PAGE}&page=${page}&status=DONE`, source)
       .then(({ data }: { data: RawMatchType[] }) => {
         const match: MatchType[] = data.map((info) => ({
           ...info,
@@ -90,9 +97,9 @@ const MatchHistory = () => {
     <>
       {matchHistories.map((matchHistory) => (
         <MatchListItem
-          opposite={matchHistory.user1.id === me.id ? matchHistory.user2 : matchHistory.user1}
+          opposite={matchHistory.user1.name === username ? matchHistory.user2 : matchHistory.user1}
           mode={matchHistory.mode}
-          isMeWinner={matchHistory.winner?.id === me.id}
+          isMeWinner={matchHistory.winner?.name === username}
           createdAt={matchHistory.createdAt}
           key={matchHistory.id}
         />
@@ -122,10 +129,10 @@ const MatchHistory = () => {
   );
 };
 
-const AchievementList = () => {
+const AchievementList = ({ username }: AchievementProps) => {
   const [Achieves, setAchieves] = useState<AchievementType[]>([]);
   const [isLoaded, setLoaded] = useState<boolean>(false);
-  const path = makeAPIPath('/achievements');
+  const path = makeAPIPath(`/achievements/${username}`);
 
   useEffect(() => {
     axios.get(path)
@@ -226,13 +233,13 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
         <Grid item>
           <Typo variant="h5">Match History</Typo>
           <List height="15em" scroll>
-            <MatchHistory />
+            <MatchHistory username={username} />
           </List>
         </Grid>
         <Grid item>
           <Typo variant="h5">Achievements</Typo>
           <List height="15em" scroll>
-            <AchievementList />
+            <AchievementList username={username} />
           </List>
         </Grid>
       </Grid>

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -148,10 +148,6 @@ const AchievementList = ({ username }: UserNameType) => {
         errorMessageHandler(error);
         setLoaded(true);
       });
-  }, []);
-
-  useEffect(() => {
-    setLoaded(false);
 
     return () => {
       source.cancel();

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -126,7 +126,7 @@ const MatchHistory = ({ username }: UserNameType) => {
 };
 
 const AchievementList = ({ username }: UserNameType) => {
-  const [Achieves, setAchieves] = useState<AchievementType[]>([]);
+  const [achieves, setAchieves] = useState<AchievementType[]>([]);
   const [isLoaded, setLoaded] = useState<boolean>(false);
   const path = makeAPIPath(`/users/${username}/achievements`);
 
@@ -146,7 +146,7 @@ const AchievementList = ({ username }: UserNameType) => {
 
   return (
     <>
-      {Achieves.map((achievement) => (
+      {achieves.map((achievement) => (
         <AchieveListItem
           info={achievement}
           key={achievement.name}

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -146,7 +146,18 @@ const AchievementList = ({ username }: UserNameType) => {
       .catch((error) => {
         source.cancel();
         errorMessageHandler(error);
+        setLoaded(true);
       });
+  }, []);
+
+  useEffect(() => {
+    setLoaded(false);
+
+    return () => {
+      source.cancel();
+      setAchieves([]);
+      setLoaded(true);
+    };
   }, []);
 
   return (

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -143,7 +143,10 @@ const AchievementList = ({ username }: UserNameType) => {
         setLoaded(true);
         setAchieves(Achievements);
       })
-      .catch((error) => { errorMessageHandler(error); });
+      .catch((error) => {
+        source.cancel();
+        errorMessageHandler(error);
+      });
   }, []);
 
   return (

--- a/src/types/Game.ts
+++ b/src/types/Game.ts
@@ -17,6 +17,12 @@ export enum AchievementDescription {
   FIRST_BLOCK = 'You made your first hater.',
 }
 
+export type RawAchievementType = {
+  name: AchievementName,
+  description: AchievementDescription,
+  createdAt: string,
+};
+
 export type AchievementType = {
   name: AchievementName,
   description: AchievementDescription,


### PR DESCRIPTION
## 기능에 대한 설명

MatchHistory List와 Achievements List를 구현했습니다. MatchHistory List는 페이지네이션이 구현된 ChannelPage, GameWatchPage 등을 참고해서 만들었습니다. Achievements List는 페이지네이션 없이 구현했습니다.

Achievements List에서 GET 응답을 받는 동안 AchieveListItemSkeleton을 적용했는 데, 속도가 너무 빨라서 잘 안보입니다. 그래서 setTimeout을 적용시킬지 고민했으나 setTimeout은 적용하지 않았습니다.

## 테스트 (Optional)
- [x] MatchHistory 페이지네이션 확인
- [x] Achievement 동작 확인 

## REFERENCE (Optional)

.

## ISSUE

issue #74의
- [x] 업적 리스트 구현
- [x] 전적 리스트 구현
