### PR TITLE
Feat: 게임 플레이 관련 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,10 +130,9 @@ const App = () => {
         });
 
         socket.on('invitedToMatch', ({ mode, opponentId }) => {
-          // eslint-disable-next-line no-console
-          console.log('invited by', opponentId);
-          handleInvited(mode, opponentId);
+          handleInvited(mode, opponentId, socket);
           // FIXME: 여러 명으로부터 한번에 초대받을 때 어떻게 할지?
+          // NOTE 큐 하나 만들고 뭐 하나 수락할때까지 Dialog 내용 바꿔가며 띄워주기?
         });
       });
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -129,8 +129,8 @@ const App = () => {
           }
         });
 
-        socket.on('invitedToMatch', ({ mode, opponentId }) => {
-          handleInvited(mode, opponentId, socket);
+        socket.on('invitedToMatch', ({ mode, opponent }) => {
+          handleInvited(mode, opponent, socket);
           // FIXME: 여러 명으로부터 한번에 초대받을 때 어떻게 할지?
           // NOTE 큐 하나 만들고 뭐 하나 수락할때까지 Dialog 내용 바꿔가며 띄워주기?
         });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,10 +130,8 @@ const App = () => {
           }
         });
 
-        socket.on('invitedToMatch', ({ mode, opponent }) => {
-          handleInvited(mode, opponent, socket);
-          // FIXME: 여러 명으로부터 한번에 초대받을 때 어떻게 할지?
-          // NOTE 큐 하나 만들고 뭐 하나 수락할때까지 Dialog 내용 바꿔가며 띄워주기?
+        socket.on('invitedToMatch', ({ mode, opponent, opponentSocketId }) => {
+          handleInvited(mode, opponent, opponentSocketId, socket);
         });
       });
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,9 @@ import ChannelManagePage from './components/pages/ChannelManagePage/ChannelManag
 import DMPage from './components/pages/DMPage/DMPage';
 import { RawUserInfoType } from './types/Response';
 import GamePage from './components/pages/GamePage/GamePage';
+import Dialog from './components/molecules/Dialog/Dialog';
+import useDialog from './utils/hooks/useDialog';
+import useMatch from './utils/hooks/useMatch';
 
 const useStyles = makeStyles({
   progress: {
@@ -77,6 +80,10 @@ const App = () => {
   const [userInfo, setUserInfo] = useState<RawUserInfoType | null>(null);
   const [channels, setChannels] = useState<ChannelType[]>([]);
   const [DMs, setDMs] = useState<DMRoomType[]>([]);
+  const {
+    isOpen, setOpen, dialog, setDialog,
+  } = useDialog();
+  const { handleInvited } = useMatch(setOpen, setDialog);
 
   useEffect(() => {
     if (userInfo) {
@@ -120,6 +127,13 @@ const App = () => {
             history.push('/channel');
             toast.warn(`${name} 채널의 권한이 관리자에서 멤버로 변경되었습니다.`);
           }
+        });
+
+        socket.on('invitedToMatch', ({ mode, opponentId }) => {
+          // eslint-disable-next-line no-console
+          console.log('invited by', opponentId);
+          handleInvited(mode, opponentId);
+          // FIXME: 여러 명으로부터 한번에 초대받을 때 어떻게 할지?
         });
       });
     }
@@ -188,6 +202,13 @@ const App = () => {
 
   const children = userState.id ? (
     <>
+      <Dialog
+        title={dialog.title}
+        content={dialog.content}
+        buttons={dialog.buttons}
+        isOpen={isOpen}
+        onClose={dialog.onClose}
+      />
       <Switch>
         <Route path="/">
           <MainTemplate

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -187,37 +187,39 @@ const App = () => {
   }, []);
 
   const children = userState.id ? (
+    <>
+      <Switch>
+        <Route path="/">
+          <MainTemplate
+            main={(
+              <Switch>
+                <Route exact path="/">
+                  <Redirect to="/game" />
+                </Route>
+                <Route path="/game" component={GamePage} />
+                <Route path="/community" component={CommunityPage} />
+                <Route path="/channel/manage/:channelName" component={ChannelManagePage} />
+                <Route path="/channel" component={ChannelPage} />
+                <Route path="/profile/:username" component={ProfilePage} />
+                <Route exact path="/dm" component={DMPage} />
+                <Route exact path="/profile">
+                  <Redirect to={`/profile/${userState.name}`} />
+                </Route>
+                <Route exact path="/404" render={() => <h1>404 Not found</h1>} />
+                <Route path="/">
+                  <Redirect to="/404" />
+                </Route>
+              </Switch>
+      )}
+            chat={<ChatPage />}
+          />
+        </Route>
+      </Switch>
+    </>
+  ) : (
     <Switch>
       <Route exact path="/register/2fa" component={MFARegisterPage} />
       <Route exact path="/2fa" component={MFAPage} />
-      <Route path="/">
-        <MainTemplate
-          main={(
-            <Switch>
-              <Route exact path="/">
-                <Redirect to="/game" />
-              </Route>
-              <Route path="/game" component={GamePage} />
-              <Route path="/community" component={CommunityPage} />
-              <Route path="/channel/manage/:channelName" component={ChannelManagePage} />
-              <Route path="/channel" component={ChannelPage} />
-              <Route path="/profile/:username" component={ProfilePage} />
-              <Route exact path="/dm" component={DMPage} />
-              <Route exact path="/profile">
-                <Redirect to={`/profile/${userState.name}`} />
-              </Route>
-              <Route exact path="/404" render={() => <h1>404 Not found</h1>} />
-              <Route path="/">
-                <Redirect to="/404" />
-              </Route>
-            </Switch>
-      )}
-          chat={<ChatPage />}
-        />
-      </Route>
-    </Switch>
-  ) : (
-    <Switch>
       <Route exact path="/register" component={RegisterPage} />
       <Route path="/" component={LoginPage} />
     </Switch>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import {
-  Switch, Route, Redirect, useHistory,
+  Switch, Route, Redirect, useHistory, useLocation,
 } from 'react-router-dom';
 import axios from 'axios';
 import { io } from 'socket.io-client';
@@ -77,6 +77,7 @@ const App = () => {
   const userDispatch = useUserDispatch();
   const classes = useStyles();
   const history = useHistory();
+  const location = useLocation();
   const [userInfo, setUserInfo] = useState<RawUserInfoType | null>(null);
   const [channels, setChannels] = useState<ChannelType[]>([]);
   const [DMs, setDMs] = useState<DMRoomType[]>([]);
@@ -123,7 +124,7 @@ const App = () => {
             channels: appState.channels.map((channel) => (
               channel.name === name ? { ...channel, role: 'MEMBER' } : { ...channel })),
           });
-          if (window.location.pathname === `/channel/manage/${encodeURI(name)}`) {
+          if (location.pathname === `/channel/manage/${encodeURI(name)}`) {
             history.push('/channel');
             toast.warn(`${name} 채널의 권한이 관리자에서 멤버로 변경되었습니다.`);
           }

--- a/src/components/atoms/List/List.tsx
+++ b/src/components/atoms/List/List.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ForwardedRef } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Typo from '../Typo/Typo';
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
     margin: '0.5em auto',
     backgroundColor: '#eee',
     borderRadius: '10px',
-    padding: '5px',
+    padding: '5px !important',
     overflowX: 'hidden',
     overflowY: (props: StyleProps) => (props.scroll ? 'auto' : 'hidden'),
     '&::-webkit-scrollbar': {
@@ -43,14 +43,16 @@ type ListProps = {
   children?: React.ReactNode,
 };
 
-const List = ({
+const List = React.forwardRef(({
   height, scroll, reverse, children,
-}: ListProps) => {
+}: ListProps, ref?: ForwardedRef<HTMLDivElement>) => {
   const classes = useStyles({ height, scroll } as StyleProps);
   return (
     <Grid
       item
       container
+      ref={ref || null}
+      style={{ position: 'relative' }}
       className={classes.root}
       direction={reverse ? 'column-reverse' : 'column'}
       justifyContent="flex-start"
@@ -66,7 +68,7 @@ const List = ({
       )}
     </Grid>
   );
-};
+});
 
 List.defaultProps = {
   height: '25vh',

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -9,28 +9,46 @@ type DialogProps = {
   content: React.ReactNode,
   buttons?: React.ReactNode,
   isOpen: boolean,
+  container?: HTMLElement | React.Component | (() => (React.ReactInstance | null)),
   // eslint-disable-next-line no-unused-vars
   onClose: (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => void,
 };
 
 const Dialog = ({
-  title, content, buttons, isOpen, onClose,
+  title, content, buttons, isOpen, onClose, container,
 }: DialogProps) => (
-  <MaterialDialog
-    open={isOpen}
-    onClose={onClose}
-    aria-labelledby="alert-dialog-title"
-    aria-describedby="alert-dialog-description"
-  >
-    {title && <DialogTitle>{title}</DialogTitle>}
-    <DialogContent>{content}</DialogContent>
-    <DialogActions>{buttons}</DialogActions>
-  </MaterialDialog>
+  container ? (
+    <MaterialDialog
+      open={isOpen}
+      onClose={onClose}
+      container={container || document.body}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+      style={{ position: 'absolute' }}
+      BackdropProps={{ style: { position: 'absolute' } }}
+    >
+      {title && <DialogTitle>{title}</DialogTitle>}
+      <DialogContent>{content}</DialogContent>
+      <DialogActions>{buttons}</DialogActions>
+    </MaterialDialog>
+  ) : (
+    <MaterialDialog
+      open={isOpen}
+      onClose={onClose}
+      aria-labelledby="alert-dialog-title"
+      aria-describedby="alert-dialog-description"
+    >
+      {title && <DialogTitle>{title}</DialogTitle>}
+      <DialogContent>{content}</DialogContent>
+      <DialogActions>{buttons}</DialogActions>
+    </MaterialDialog>
+  )
 );
 
 Dialog.defaultProps = {
   title: null,
   buttons: null,
+  container: null,
 };
 
 export default Dialog;

--- a/src/components/molecules/Dialog/Dialog.tsx
+++ b/src/components/molecules/Dialog/Dialog.tsx
@@ -26,6 +26,7 @@ const Dialog = ({
       aria-describedby="alert-dialog-description"
       style={{ position: 'absolute' }}
       BackdropProps={{ style: { position: 'absolute' } }}
+      fullWidth
     >
       {title && <DialogTitle>{title}</DialogTitle>}
       <DialogContent>{content}</DialogContent>

--- a/src/components/molecules/GameOptionCard/GameOptionCard.stories.tsx
+++ b/src/components/molecules/GameOptionCard/GameOptionCard.stories.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles({
   },
 });
 
-export const Watch = () => <Grid xs={4}><GameOptionCard option="watch" onClick={() => {}} /></Grid>;
+export const Watch = () => <Grid xs={4}><GameOptionCard option="WATCH" onClick={() => {}} /></Grid>;
 
 export const WithMainTemplate = () => {
   const classes = useStyles();
@@ -33,18 +33,18 @@ export const WithMainTemplate = () => {
             <>
               <Grid container justifyContent="space-evenly" alignItems="center" spacing={1}>
                 <Grid item xs={6}>
-                  <GameOptionCard option="classic" onClick={() => {}} />
+                  <GameOptionCard option="CLASSIC" onClick={() => {}} />
                 </Grid>
                 <Grid item xs={6}>
-                  <GameOptionCard option="speed" onClick={() => {}} />
+                  <GameOptionCard option="SPEED" onClick={() => {}} />
                 </Grid>
               </Grid>
               <Grid container justifyContent="space-evenly" alignItems="center" spacing={1}>
                 <Grid item xs={6}>
-                  <GameOptionCard option="reverse" onClick={() => {}} />
+                  <GameOptionCard option="REVERSE" onClick={() => {}} />
                 </Grid>
                 <Grid item xs={6}>
-                  <GameOptionCard option="watch" onClick={() => {}} />
+                  <GameOptionCard option="WATCH" onClick={() => {}} />
                 </Grid>
               </Grid>
             </>

--- a/src/components/molecules/GameOptionCard/GameOptionCard.tsx
+++ b/src/components/molecules/GameOptionCard/GameOptionCard.tsx
@@ -5,6 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardContent from '@material-ui/core/CardContent';
 import Typo from '../../atoms/Typo/Typo';
+import { GameModeType } from '../../../types/Match';
 
 const useStyles = makeStyles({
   card: {
@@ -25,10 +26,8 @@ const useStyles = makeStyles({
   },
 });
 
-type GameOptionType = 'classic' | 'speed' | 'reverse' | 'watch';
-
 type GameOptionCardProps = {
-  option: GameOptionType,
+  option: GameModeType | 'WATCH',
   onClick: React.MouseEventHandler<HTMLButtonElement>,
 };
 
@@ -96,15 +95,15 @@ const GameOptionCard = ({ option, onClick } : GameOptionCardProps) => {
     />
   );
 
-  const ChooseOption = (opt: GameOptionType) => {
+  const ChooseOption = (opt: GameModeType | 'WATCH') => {
     switch (opt) {
-      case 'watch':
+      case 'WATCH':
         return (<WatchGame />);
-      case 'speed':
+      case 'SPEED':
         return (<SpeedGame />);
-      case 'reverse':
+      case 'REVERSE':
         return (<ReverseGame />);
-      case 'classic':
+      case 'CLASSIC':
       default:
         return (<ClassicGame />);
     }

--- a/src/components/molecules/Menu/Menu.tsx
+++ b/src/components/molecules/Menu/Menu.tsx
@@ -12,6 +12,9 @@ const useStyles = makeStyles({
   cursor: {
     cursor: 'pointer',
   },
+  root: {
+    paddingRight: '0 !important',
+  },
 });
 
 const Menu = () => {
@@ -45,7 +48,7 @@ const Menu = () => {
   );
 
   return (
-    <AppBar>
+    <AppBar className={classes.root}>
       <Toolbar>
         <Grid container>
           <Link to="/game" style={{ textDecoration: 'none', color: 'inherit' }}>

--- a/src/components/molecules/UserProfile/UserProfile.stories.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.stories.tsx
@@ -15,9 +15,12 @@ export const Default: Story<RelatedInfoType> = ({ status }: RelatedInfoType) => 
     avatar: '',
     status,
     relationship: 'NONE',
+    score: 0,
+    win: 0,
+    lose: 0,
   };
 
-  return <UserProfile userInfo={userInfo} />;
+  return <UserProfile profile userInfo={userInfo} />;
 };
 
 Default.args = {

--- a/src/components/molecules/UserProfile/UserProfile.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.tsx
@@ -6,6 +6,7 @@ import StarRoundedIcon from '@material-ui/icons/StarRounded';
 import { RelatedInfoType, UserStatusType } from '../../../types/User';
 import Avatar from '../../atoms/Avatar/Avatar';
 import Typo from '../../atoms/Typo/Typo';
+import { makeMatchHistoryString } from '../../../utils/utils';
 
 type StyleProps = { status: UserStatusType };
 
@@ -40,7 +41,7 @@ export type UserProfileProps = {
 
 const UserProfile = ({ userInfo, profile }: UserProfileProps) => {
   const {
-    name, avatar, status, relationship,
+    name, avatar, status, relationship, score, win, lose,
   } = userInfo;
   const classes = useStyles({ status });
 
@@ -77,14 +78,12 @@ const UserProfile = ({ userInfo, profile }: UserProfileProps) => {
       <Grid item xs={6}>
         <Typo variant={profile ? 'h5' : 'h6'}>{name}</Typo>
         <Typo className={classes.status}>{makeStatusString()}</Typo>
-        {profile && (
-        <Typo
-          variant="body2"
-          // FIXME: game 관련 정보가 fix되면 수정해야 합니다.
-        >
-          n점 / n승 n패 (임시)
-        </Typo>
+        {(profile && score) && (
+          <Typo variant="body2">
+            {makeMatchHistoryString(score!, win!, lose!)}
+          </Typo>
         )}
+
       </Grid>
     </Grid>
   );

--- a/src/components/molecules/UserProfile/UserProfile.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.tsx
@@ -83,7 +83,6 @@ const UserProfile = ({ userInfo, profile }: UserProfileProps) => {
             {makeMatchHistoryString(score!, win!, lose!)}
           </Typo>
         )}
-
       </Grid>
     </Grid>
   );

--- a/src/components/molecules/UserProfile/UserProfile.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.tsx
@@ -78,7 +78,7 @@ const UserProfile = ({ userInfo, profile }: UserProfileProps) => {
       <Grid item xs={6}>
         <Typo variant={profile ? 'h5' : 'h6'}>{name}</Typo>
         <Typo className={classes.status}>{makeStatusString()}</Typo>
-        {(profile && score) && (
+        {(profile && score !== undefined) && (
           <Typo variant="body2">
             {makeMatchHistoryString(score!, win!, lose!)}
           </Typo>

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -11,8 +11,7 @@ import { SetDialogType, SetOpenType } from '../../../utils/hooks/useDialog';
 import Button from '../../atoms/Button/Button';
 import { makeMatchHistoryString } from '../../../utils/utils';
 import useMatch from '../../../utils/hooks/useMatch';
-
-const PLAY_PATH = '/game/play';
+import { PLAY_PATH } from '../../../utils/path';
 
 type StyleProps = { me: boolean };
 

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -10,6 +10,7 @@ import Typo from '../../atoms/Typo/Typo';
 import { SetDialogType, SetOpenType } from '../../../utils/hooks/useDialog';
 import Button from '../../atoms/Button/Button';
 import { makeMatchHistoryString } from '../../../utils/utils';
+import useMatch from '../../../utils/hooks/useMatch';
 
 type StyleProps = { me: boolean };
 
@@ -58,8 +59,9 @@ const ChatMessage = ({
 }: ChatProps) => {
   const { user } = info;
   const {
-    name, avatar, score, win, lose,
+    id, name, avatar, score, win, lose,
   } = user;
+  const { inviteUser } = useMatch(setOpen, setDialog);
   const classes = useStyles({ me });
   const history = useHistory();
 
@@ -70,9 +72,9 @@ const ChatMessage = ({
         <Grid container direction="column" justifyContent="center" alignItems="center">
           <Typo gutterBottom>초대할 게임 모드를 선택해주세요.</Typo>
           <Grid item container justifyContent="center" alignItems="center">
-            <Button variant="outlined">CLASSIC</Button>
-            <Button variant="outlined">SPEED</Button>
-            <Button variant="outlined">REVERSE</Button>
+            <Button variant="outlined" onClick={() => inviteUser('CLASSIC', id)}>CLASSIC</Button>
+            <Button variant="outlined" onClick={() => inviteUser('SPEED', id)}>SPEED</Button>
+            <Button variant="outlined" onClick={() => inviteUser('REVERSE', id)}>REVERSE</Button>
           </Grid>
         </Grid>),
       buttons: <Button variant="text" onClick={() => { setOpen(false); }}>close</Button>,

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 import Badge from '@material-ui/core/Badge';
 import Grid from '@material-ui/core/Grid';
 import SecurityRoundedIcon from '@material-ui/icons/SecurityRounded';
@@ -11,6 +11,8 @@ import { SetDialogType, SetOpenType } from '../../../utils/hooks/useDialog';
 import Button from '../../atoms/Button/Button';
 import { makeMatchHistoryString } from '../../../utils/utils';
 import useMatch from '../../../utils/hooks/useMatch';
+
+const PLAY_PATH = '/game/play';
 
 type StyleProps = { me: boolean };
 
@@ -64,6 +66,7 @@ const ChatMessage = ({
   const { inviteUser } = useMatch(setOpen, setDialog);
   const classes = useStyles({ me });
   const history = useHistory();
+  const location = useLocation();
 
   const handleMatchChoice = () => {
     setDialog({
@@ -98,7 +101,7 @@ const ChatMessage = ({
             {makeMatchHistoryString(score!, win!, lose!)}
           </Typo>
           <Button variant="outlined" onClick={handleProfileClick}>프로필 페이지</Button>
-          <Button variant="outlined" onClick={handleMatchChoice}>매치 초대하기</Button>
+          {location.pathname !== PLAY_PATH && <Button variant="outlined" onClick={handleMatchChoice}>매치 초대하기</Button>}
         </Grid>
       ),
       buttons: <Button variant="text" onClick={() => { setOpen(false); }}>close</Button>,

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -83,6 +83,11 @@ const ChatMessage = ({
     setOpen(true);
   };
 
+  const handleProfileClick = () => {
+    history.push(`/profile/${name}`);
+    setOpen(false);
+  };
+
   const handleClick = () => {
     setDialog({
       content: (
@@ -92,7 +97,7 @@ const ChatMessage = ({
           <Typo variant="body2" gutterBottom>
             {makeMatchHistoryString(score!, win!, lose!)}
           </Typo>
-          <Button variant="outlined" onClick={() => history.push(`/profile/${name}`)}>프로필 페이지</Button>
+          <Button variant="outlined" onClick={handleProfileClick}>프로필 페이지</Button>
           <Button variant="outlined" onClick={handleMatchChoice}>매치 초대하기</Button>
         </Grid>
       ),

--- a/src/components/organisms/ChatMessage/ChatMessage.tsx
+++ b/src/components/organisms/ChatMessage/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import Badge from '@material-ui/core/Badge';
 import Grid from '@material-ui/core/Grid';
 import SecurityRoundedIcon from '@material-ui/icons/SecurityRounded';
@@ -7,6 +8,8 @@ import { MembershipRole, MessageType } from '../../../types/Chat';
 import Avatar from '../../atoms/Avatar/Avatar';
 import Typo from '../../atoms/Typo/Typo';
 import { SetDialogType, SetOpenType } from '../../../utils/hooks/useDialog';
+import Button from '../../atoms/Button/Button';
+import { makeMatchHistoryString } from '../../../utils/utils';
 
 type StyleProps = { me: boolean };
 
@@ -54,13 +57,46 @@ const ChatMessage = ({
   info, userRole, me = false, setOpen, setDialog,
 }: ChatProps) => {
   const { user } = info;
+  const {
+    name, avatar, score, win, lose,
+  } = user;
   const classes = useStyles({ me });
+  const history = useHistory();
+
+  const handleMatchChoice = () => {
+    setDialog({
+      title: '매치 초대',
+      content: (
+        <Grid container direction="column" justifyContent="center" alignItems="center">
+          <Typo gutterBottom>초대할 게임 모드를 선택해주세요.</Typo>
+          <Grid item container justifyContent="center" alignItems="center">
+            <Button variant="outlined">CLASSIC</Button>
+            <Button variant="outlined">SPEED</Button>
+            <Button variant="outlined">REVERSE</Button>
+          </Grid>
+        </Grid>),
+      buttons: <Button variant="text" onClick={() => { setOpen(false); }}>close</Button>,
+      onClose: () => setOpen(false),
+    });
+    setOpen(true);
+  };
+
   const handleClick = () => {
     setDialog({
-      title: 'Menu',
-      content: 'temp chat menu',
+      content: (
+        <Grid container direction="column" justifyContent="center" alignItems="center">
+          <Avatar size="large" alt={name} src={avatar} />
+          <Typo variant="h5">{name}</Typo>
+          <Typo variant="body2" gutterBottom>
+            {makeMatchHistoryString(score!, win!, lose!)}
+          </Typo>
+          <Button variant="outlined" onClick={() => history.push(`/profile/${name}`)}>프로필 페이지</Button>
+          <Button variant="outlined" onClick={handleMatchChoice}>매치 초대하기</Button>
+        </Grid>
+      ),
+      buttons: <Button variant="text" onClick={() => { setOpen(false); }}>close</Button>,
       onClose: () => setOpen(false),
-    }); // FIXME 유저 메뉴 고쳐야 합니다
+    });
     setOpen(true);
   };
 

--- a/src/components/organisms/PlayerProfile/PlayerProfile.stories.tsx
+++ b/src/components/organisms/PlayerProfile/PlayerProfile.stories.tsx
@@ -3,39 +3,43 @@ import { Meta } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
-import PlayerProfile, { UserGameInfoType } from './PlayerProfile';
+import PlayerProfile from './PlayerProfile';
 import ContextProvider from '../../../utils/hooks/useContext';
 import MainTemplate from '../../templates/MainTemplate/MainTemplate';
 import Typo from '../../atoms/Typo/Typo';
+import { UserInfoType } from '../../../types/User';
 
 export default {
   title: 'organisms/PlayerProfile',
   component: PlayerProfile,
 } as Meta;
 
-const dummyUserGameInfo: UserGameInfoType = {
+const dummyUserGameInfo: UserInfoType = {
   id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
   name: 'USERNAME',
   avatar: '',
   status: 'OFFLINE',
+  score: 0,
   win: 0,
   lose: 0,
 };
 
-const jikangGameInfo: UserGameInfoType = {
+const jikangGameInfo: UserInfoType = {
   id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
   name: 'Jikang',
   avatar: 'https://cdn.intra.42.fr/users/medium_jikang.jpg',
   status: 'IN_GAME',
+  score: 0,
   win: 4,
   lose: 2,
 };
 
-const fakeUserGameInfo: UserGameInfoType = {
+const fakeUserGameInfo: UserInfoType = {
   id: '550e8400-e29b-41d4-a716-446655440000', // 의미없는 uuid입니다
   name: 'ABCDEFGHIJK',
   avatar: 'https://cdn.intra.42.fr/users/medium_default.png',
   status: 'IN_GAME',
+  score: 0,
   win: 40,
   lose: 20,
 };

--- a/src/components/organisms/PlayerProfile/PlayerProfile.tsx
+++ b/src/components/organisms/PlayerProfile/PlayerProfile.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
-import ListItem from '../../atoms/ListItem/ListItem';
 import { UserInfoType } from '../../../types/User';
 import Avatar from '../../atoms/Avatar/Avatar';
 import Typo from '../../atoms/Typo/Typo';
@@ -30,21 +29,13 @@ const PlayerProfile = ({ userGameInfo }: PlayerProfileProps) => {
   const makeMatchHistoryString = (): string => (`전적 ${win}승 ${lose}패`);
 
   return (
-    <ListItem>
-      <Grid className={classes.root} item container justifyContent="center" alignItems="center">
-        <Grid item container justifyContent="center" alignItems="center" xs={12}>
-          <Avatar src={avatar} alt={name} />
-        </Grid>
-        <Grid item container justifyContent="center" alignItems="center" xs={12}>
-          <Typo variant="body1">{name}</Typo>
-        </Grid>
-        <Grid item container justifyContent="center" alignItems="center" xs={12}>
-          <Typo variant="body2">
-            {makeMatchHistoryString()}
-          </Typo>
-        </Grid>
-      </Grid>
-    </ListItem>
+    <Grid className={classes.root} item container xs={12} direction="column" justifyContent="center" alignItems="center">
+      <Avatar src={avatar} alt={name} />
+      <Typo variant="body1">{name}</Typo>
+      <Typo variant="body2">
+        {makeMatchHistoryString()}
+      </Typo>
+    </Grid>
   );
 };
 

--- a/src/components/organisms/PlayerProfile/PlayerProfile.tsx
+++ b/src/components/organisms/PlayerProfile/PlayerProfile.tsx
@@ -4,12 +4,10 @@ import Grid from '@material-ui/core/Grid';
 import { UserInfoType } from '../../../types/User';
 import Avatar from '../../atoms/Avatar/Avatar';
 import Typo from '../../atoms/Typo/Typo';
-
-// FIXME: 임시 Type 작성
-export type UserGameInfoType = UserInfoType & { win: number, lose: number };
+import { makeMatchHistoryString } from '../../../utils/utils';
 
 type PlayerProfileProps = {
-  userGameInfo: UserGameInfoType,
+  userGameInfo: UserInfoType,
 };
 
 const useStyles = makeStyles({
@@ -22,18 +20,16 @@ const useStyles = makeStyles({
 
 const PlayerProfile = ({ userGameInfo }: PlayerProfileProps) => {
   const {
-    name, avatar, win, lose,
+    name, avatar, score, win, lose,
   } = userGameInfo;
   const classes = useStyles();
-
-  const makeMatchHistoryString = (): string => (`전적 ${win}승 ${lose}패`);
 
   return (
     <Grid className={classes.root} item container xs={12} direction="column" justifyContent="center" alignItems="center">
       <Avatar src={avatar} alt={name} />
       <Typo variant="body1">{name}</Typo>
       <Typo variant="body2">
-        {makeMatchHistoryString()}
+        {makeMatchHistoryString(score!, win!, lose!)}
       </Typo>
     </Grid>
   );

--- a/src/components/organisms/ProfileCard/ProfileCard.stories.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.stories.tsx
@@ -27,6 +27,9 @@ export const OthersProfile = () => {
     avatar: '',
     status: 'OFFLINE',
     relationship: 'NONE',
+    score: 0,
+    win: 0,
+    lose: 0,
   };
 
   return (
@@ -105,6 +108,9 @@ export const OthersList = () => {
     avatar: '',
     status: 'OFFLINE',
     relationship: 'NONE',
+    score: 0,
+    win: 0,
+    lose: 0,
   };
 
   return (
@@ -192,6 +198,9 @@ const ProfileCardWithContext = () => {
     avatar: '',
     status: 'ONLINE',
     relationship: 'NONE',
+    score: 0,
+    win: 0,
+    lose: 0,
   };
 
   useEffect(() => {

--- a/src/components/organisms/ProfileCard/ProfileCard.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.tsx
@@ -14,6 +14,7 @@ import UserInfoForm from '../UserInfoForm/UserInfoForm';
 import { errorMessageHandler, makeAPIPath } from '../../../utils/utils';
 import { makeRelationship } from '../../../utils/friendships';
 import Typo from '../../atoms/Typo/Typo';
+import useMatch from '../../../utils/hooks/useMatch';
 
 const useStyles = makeStyles({
   root: {
@@ -105,6 +106,7 @@ const ProfileCard = ({
   const {
     id, name, relationship,
   } = userInfo;
+  const { inviteUser } = useMatch(setOpen, setDialog);
   const me = useUserState();
   const appDispatch = useAppDispatch();
   const appState = useAppState();
@@ -385,16 +387,15 @@ const ProfileCard = ({
               <Grid container direction="column" justifyContent="center" alignItems="center">
                 <Typo gutterBottom>초대할 게임 모드를 선택해주세요.</Typo>
                 <Grid item container>
-                  <Button variant="outlined">CLASSIC</Button>
-                  <Button variant="outlined">SPEED</Button>
-                  <Button variant="outlined">REVERSE</Button>
+                  <Button variant="outlined" onClick={() => inviteUser('CLASSIC', id)}>CLASSIC</Button>
+                  <Button variant="outlined" onClick={() => inviteUser('SPEED', id)}>SPEED</Button>
+                  <Button variant="outlined" onClick={() => inviteUser('REVERSE', id)}>REVERSE</Button>
                 </Grid>
               </Grid>),
             buttons: <Button variant="text" onClick={() => { setOpen(false); }}>cancel</Button>,
             onClose: () => { setOpen(false); },
           });
           setOpen(true);
-          // FIXME: API 맞춰서 수정
         },
       },
     ];

--- a/src/components/organisms/ProfileCard/ProfileCard.tsx
+++ b/src/components/organisms/ProfileCard/ProfileCard.tsx
@@ -13,6 +13,7 @@ import { SetDialogType, SetOpenType } from '../../../utils/hooks/useDialog';
 import UserInfoForm from '../UserInfoForm/UserInfoForm';
 import { errorMessageHandler, makeAPIPath } from '../../../utils/utils';
 import { makeRelationship } from '../../../utils/friendships';
+import Typo from '../../atoms/Typo/Typo';
 
 const useStyles = makeStyles({
   root: {
@@ -378,7 +379,22 @@ const ProfileCard = ({
       {
         text: '매치 초대',
         onClick: () => {
-          // TODO: API 구현 후, 추가
+          setDialog({
+            title: '매치 초대',
+            content: (
+              <Grid container direction="column" justifyContent="center" alignItems="center">
+                <Typo gutterBottom>초대할 게임 모드를 선택해주세요.</Typo>
+                <Grid item container>
+                  <Button variant="outlined">CLASSIC</Button>
+                  <Button variant="outlined">SPEED</Button>
+                  <Button variant="outlined">REVERSE</Button>
+                </Grid>
+              </Grid>),
+            buttons: <Button variant="text" onClick={() => { setOpen(false); }}>cancel</Button>,
+            onClose: () => { setOpen(false); },
+          });
+          setOpen(true);
+          // FIXME: API 맞춰서 수정
         },
       },
     ];

--- a/src/components/pages/ChannelPage/ChannelPage.tsx
+++ b/src/components/pages/ChannelPage/ChannelPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import {
+  Redirect, Route, Switch, useLocation,
+} from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
@@ -137,6 +139,7 @@ const AllList = () => <ChannelList type="all" />;
 
 const ChannelPage = () => {
   const classes = useStyles();
+  const location = useLocation();
   const { isOpen, setOpen } = useDialog();
 
   return (
@@ -149,7 +152,7 @@ const ChannelPage = () => {
       />
       <Grid container>
         <Grid item container justifyContent="center" xs={10}>
-          <SubMenu current={window.location.pathname} list={list} />
+          <SubMenu current={location.pathname} list={list} />
         </Grid>
         <Grid item container justifyContent="flex-end" xs={2}>
           <Button className={classes.button} variant="outlined" onClick={() => setOpen(true)}>채널 개설</Button>

--- a/src/components/pages/ChatPage/ChatPage.tsx
+++ b/src/components/pages/ChatPage/ChatPage.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import React, { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import Grid from '@material-ui/core/Grid';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { useAppDispatch, useAppState } from '../../../utils/hooks/useAppContext';
@@ -18,6 +19,7 @@ import useIntersect from '../../../utils/hooks/useIntersect';
 import { DMToMessage, messageToMessage } from '../../../utils/chats';
 import Button from '../../atoms/Button/Button';
 import { getMembership } from '../../../utils/channels';
+import { PLAY_PATH } from '../../../utils/path';
 
 const COUNTS_PER_PAGE = 20;
 
@@ -48,6 +50,7 @@ const ChatPage = () => {
   const {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
+  const location = useLocation();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setChat(e.target.value);
@@ -119,6 +122,10 @@ const ChatPage = () => {
       setChats((prev) => addNewChat(prev, newMessage));
     }
   }, [newMessage]);
+
+  useEffect(() => {
+    if (location.pathname === PLAY_PATH) setOpen(false);
+  }, [location.pathname]);
 
   useEffect(() => () => {
     source.cancel();

--- a/src/components/pages/ChatPage/ChatPage.tsx
+++ b/src/components/pages/ChatPage/ChatPage.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import { useAppDispatch, useAppState } from '../../../utils/hooks/useAppContext';
@@ -34,6 +34,7 @@ const ChatPage = () => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
   const userState = useUserState();
+  const container = useRef<HTMLDivElement>(null);
   const [chats, setChats] = useState<MessageType[]>([]);
   const [chat, setChat] = useState<string>('');
   const [isChatEnd, setChatEnd] = useState(false);
@@ -137,6 +138,7 @@ const ChatPage = () => {
         content={dialog.content}
         buttons={dialog.buttons}
         onClose={dialog.onClose}
+        container={() => container.current}
       />
       <Grid container justifyContent="space-between" alignItems="center">
         <Typo variant="h6">{chatting?.name || '참여중인 채팅이 없습니다'}</Typo>
@@ -144,7 +146,7 @@ const ChatPage = () => {
       </Grid>
       {chatting ? (
         <>
-          <List height="70vh" reverse scroll>
+          <List height="70vh" ref={container} reverse scroll>
             {chats.map((one) => (chatting.type === 'channel' && blockList.includes(one.user.name) ? <></>
               : (
                 <ChatMessage

--- a/src/components/pages/ChatPage/ChatPage.tsx
+++ b/src/components/pages/ChatPage/ChatPage.tsx
@@ -93,6 +93,7 @@ const ChatPage = () => {
     setChat('');
     setPage(chatting ? 1 : 0);
     setChatEnd(!chatting);
+    source.cancel();
     if (chatting && chatting.type === 'channel') {
       asyncGetRequest(makeAPIPath(`/channels/${chatting.name}/members`))
         .then(({ data }) => { setMembers(data); })

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import {
+  Redirect, Route, Switch, useLocation,
+} from 'react-router-dom';
 import axios from 'axios';
 import Grid from '@material-ui/core/Grid';
 import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
@@ -157,20 +159,23 @@ const list = [
   { name: 'BLOCKED USER', link: BLOCKED_PATH },
 ];
 
-const CommunityPage = () => (
-  <>
-    <SubMenu current={window.location.pathname} list={list} />
-    <List height="78vh" scroll>
-      <Switch>
-        <Route exact path={FRIEND_PATH} component={FriendList} />
-        <Route exact path={BLOCKED_PATH} component={BlockList} />
-        <Route exact path={ALL_PATH} component={AllList} />
-        <Route path="/">
-          <Redirect to={FRIEND_PATH} />
-        </Route>
-      </Switch>
-    </List>
-  </>
-);
+const CommunityPage = () => {
+  const location = useLocation();
+  return (
+    <>
+      <SubMenu current={location.pathname} list={list} />
+      <List height="78vh" scroll>
+        <Switch>
+          <Route exact path={FRIEND_PATH} component={FriendList} />
+          <Route exact path={BLOCKED_PATH} component={BlockList} />
+          <Route exact path={ALL_PATH} component={AllList} />
+          <Route path="/">
+            <Redirect to={FRIEND_PATH} />
+          </Route>
+        </Switch>
+      </List>
+    </>
+  );
+};
 
 export default CommunityPage;

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -15,6 +15,8 @@ import Typo from '../../atoms/Typo/Typo';
 import GamePlayPage from '../GamePlayPage/GamePlayPage';
 import { GameContextProvider, useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
 import { RawUserInfoType } from '../../../types/Response';
+import { MatchPositionType } from '../../../types/Match';
+import { makeAPIPath } from '../../../utils/utils';
 
 const MAIN_GAME_PAGE = '/game';
 const PLAY_PATH = '/game/play';
@@ -43,10 +45,16 @@ const GameMainPage = () => {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
 
-  const handleReady = (position: 'LEFT' | 'RIGHT', player0: RawUserInfoType, player1: RawUserInfoType, setting: any) => {
-    // eslint-disable-next-line no-console
-    console.log(player0, player1);
-    gameDispatch({ type: 'ready', setting, position });
+  const handleReady = (
+    position: MatchPositionType, player0: RawUserInfoType, player1: RawUserInfoType, setting: any,
+  ) => {
+    gameDispatch({
+      type: 'ready',
+      position,
+      player0: { ...player0, avatar: makeAPIPath(`/${player0.avatar}`) },
+      player1: { ...player1, avatar: makeAPIPath(`/${player1.avatar}`) },
+      setting,
+    });
     socket?.off('ready');
     setOpen(false);
     history.push(PLAY_PATH);

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -39,7 +39,6 @@ const GameMainPage = () => {
   const history = useHistory();
   const classes = useStyles();
   const { mode } = useGameState();
-  // const { mode, setting } = useGameState();
   const gameDispatch = useGameDispatch();
   const { socket } = useAppState();
   const {
@@ -51,6 +50,13 @@ const GameMainPage = () => {
     toast.warn('자신과 매칭되어 대기를 취소합니다.');
     gameDispatch({ type: 'reset' });
     setOpen(false);
+  };
+
+  const handleMatchExit = (gameMode: GameModeType | null) => {
+    if (gameMode) {
+      socket?.emit('leaveGame', { type: 'LADDER', mode: gameMode });
+      setOpen(false);
+    }
   };
 
   const changeMode = (gameMode: GameModeType) => {
@@ -74,6 +80,9 @@ const GameMainPage = () => {
 
   useEffect(() => {
     if (mode) handleExit(mode);
+
+    socket?.on('invitedToMatch', handleMatchExit);
+
     setDialog({
       title: 'default',
       content: (
@@ -88,6 +97,8 @@ const GameMainPage = () => {
 
     return () => {
       // if (!setting) socket?.emit('leaveGame', { type: 'LADDER', mode });
+      // FIXME 뒤로가기 할 때 매치 취소 제대로 되도록
+      socket?.off('invitedToMatch', handleMatchExit);
       socket?.off('ready');
       socket?.off('duplicated');
       setOpen(false);

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -17,10 +17,7 @@ import GamePlayPage from '../GamePlayPage/GamePlayPage';
 import { useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
 import useMatch from '../../../utils/hooks/useMatch';
 import { GameModeType } from '../../../types/Match';
-
-const MAIN_GAME_PAGE = '/game';
-const PLAY_PATH = '/game/play';
-const WATCH_PATH = '/game/watch';
+import { MAIN_GAME_PAGE, PLAY_PATH, WATCH_PATH } from '../../../utils/path';
 
 const useStyles = makeStyles({
   root: {
@@ -96,8 +93,10 @@ const GameMainPage = () => {
     });
 
     return () => {
-      // if (!setting) socket?.emit('leaveGame', { type: 'LADDER', mode });
-      // FIXME 뒤로가기 할 때 매치 취소 제대로 되도록
+      // FIXME 뒤로가기 할 때 매치 취소 되지 않는 문제 아직 해결하지 못함
+      if (socket?.listeners('ready').length && mode) {
+        socket?.emit('leaveGame', { type: 'LADDER', mode });
+      }
       socket?.off('invitedToMatch', handleMatchExit);
       socket?.off('ready');
       socket?.off('duplicated');

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Route, Switch, useHistory, Redirect,
 } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import GameOptionCard from '../../molecules/GameOptionCard/GameOptionCard';
 import GameWatchPage from '../GameWatchPage/GameWatchPage';
+import { useAppState } from '../../../utils/hooks/useAppContext';
+import useDialog from '../../../utils/hooks/useDialog';
+import Button from '../../atoms/Button/Button';
+import Dialog from '../../molecules/Dialog/Dialog';
+import { GameModeType } from '../../../types/Match';
+import Typo from '../../atoms/Typo/Typo';
 
 const MAIN_GAME_PAGE = '/game';
 const CLASSIC_PLAY_PATH = '/game/playclassic';
@@ -21,43 +28,119 @@ const useStyles = makeStyles({
     borderRadius: '10px',
     padding: '5px',
   },
+  progress: {
+    margin: '1em',
+  },
 });
 
 const GameMainPage = () => {
   const history = useHistory();
   const classes = useStyles();
+  const { socket } = useAppState();
+  const [mode, setMode] = useState<GameModeType | null>(null);
+  const {
+    isOpen, setOpen, dialog, setDialog,
+  } = useDialog();
+
+  const handleReady = (position: 'LEFT' | 'RIGHT', setting: any) => {
+    setTimeout(() => {
+      // eslint-disable-next-line no-console
+      console.log(position, setting);
+      socket?.off('ready');
+      setOpen(false);
+    }, 3000);
+  };
+
+  useEffect(() => {
+    if (!mode) {
+      socket?.off('ready');
+      setOpen(false);
+    } else if (mode === 'CLASSIC') {
+      setDialog({ ...dialog, title: 'Classic Game Matching...' });
+      socket?.on('ready', handleReady);
+      setOpen(true);
+      socket?.emit('waiting');
+    } // FIXME: 다른 모드도 추가하고 공통부분 밖으로 빼기
+    // TODO emit할 때 roomId 같이 보내달라고 요청하기
+  }, [mode]);
+
+  useEffect(() => {
+    setDialog({
+      title: 'default',
+      content: (
+        <Grid container direction="column" justifyContent="center" alignItems="center">
+          <CircularProgress size={100} className={classes.progress} aria-busy />
+          <Typo variant="subtitle1" align="center">매칭 가능한 유저를 찾는 중입니다</Typo>
+        </Grid>
+      ),
+      buttons: <Button onClick={() => setMode(null)}>매칭 취소</Button>,
+      onClose: () => setMode(null),
+    });
+  }, []);
 
   return (
     <Grid className={classes.root} container justifyContent="space-evenly" alignItems="center" spacing={3}>
+      <Dialog
+        title={dialog.title}
+        content={dialog.content}
+        buttons={dialog.buttons}
+        isOpen={isOpen}
+        onClose={dialog.onClose}
+      />
       <Grid item xs={6}>
-        <GameOptionCard option="classic" onClick={() => { history.push(CLASSIC_PLAY_PATH); }} />
+        <GameOptionCard option="CLASSIC" onClick={() => setMode('CLASSIC')} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="speed" onClick={() => { history.push(SPEED_PLAY_PATH); }} />
+        <GameOptionCard option="SPEED" onClick={() => setMode('SPEED')} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="reverse" onClick={() => { history.push(REVERSE_PLAY_PATH); }} />
+        <GameOptionCard option="REVERSE" onClick={() => setMode('REVERSE')} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="watch" onClick={() => { history.push(WATCH_PLAY_PATH); }} />
+        <GameOptionCard option="WATCH" onClick={() => { history.push(WATCH_PLAY_PATH); }} />
       </Grid>
     </Grid>
   );
 };
 
-const GamePage = () => (
-  <>
-    <Switch>
-      <Route exact path={MAIN_GAME_PAGE} component={GameMainPage} />
-      <Route exact path={CLASSIC_PLAY_PATH} render={() => <h1>Classic play</h1>} />
-      <Route exact path={SPEED_PLAY_PATH} render={() => <h1>Speedy play</h1>} />
-      <Route exact path={REVERSE_PLAY_PATH} render={() => <h1>Reverse play</h1>} />
-      <Route path={WATCH_PLAY_PATH} component={GameWatchPage} />
-      <Route exact path="/">
-        <Redirect to={MAIN_GAME_PAGE} />
-      </Route>
-    </Switch>
-  </>
-);
+const GamePage = () => {
+  const { socket } = useAppState();
+  return (
+    <>
+      {/* FIXME: button들 삭제해야 함 */}
+      <Button onClick={() => {
+        // eslint-disable-next-line no-console
+        if (socket?.emit('waiting')) console.log('emit waiting');
+      }}
+      >
+        waiting
+      </Button>
+      <Button onClick={() => {
+        // eslint-disable-next-line no-console
+        if (socket?.emit('ready')) console.log('emit ready');
+      }}
+      >
+        ready
+      </Button>
+      <Button onClick={() => {
+        // eslint-disable-next-line no-console
+        if (socket?.emit('leaveGame')) console.log('emit leave game');
+      }}
+      >
+        leaveGame
+      </Button>
+      <Switch>
+        <Route exact path={MAIN_GAME_PAGE} component={GameMainPage} />
+        <Route exact path={CLASSIC_PLAY_PATH} render={() => <h1>Classic play</h1>} />
+        <Route exact path={SPEED_PLAY_PATH} render={() => <h1>Speedy play</h1>} />
+        <Route exact path={REVERSE_PLAY_PATH} render={() => <h1>Reverse play</h1>} />
+        <Route path={WATCH_PLAY_PATH} component={GameWatchPage} />
+        <Route exact path="/">
+          <Redirect to={MAIN_GAME_PAGE} />
+        </Route>
+      </Switch>
+    </>
+  );
+};
 
 export default GamePage;

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -73,7 +73,7 @@ const GameMainPage = () => {
       setDialog({ ...dialog, title: `${mode} MODE matching...` });
       socket?.on('ready', handleReady);
       setOpen(true);
-      socket?.emit('waiting', 'LADDER', mode);
+      socket?.emit('waiting', { type: 'LADDER', mode });
     }
   }, [mode]);
 

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -13,7 +13,7 @@ import Button from '../../atoms/Button/Button';
 import Dialog from '../../molecules/Dialog/Dialog';
 import Typo from '../../atoms/Typo/Typo';
 import GamePlayPage from '../GamePlayPage/GamePlayPage';
-import { GameContextProvider, useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
+import { useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
 import { RawUserInfoType } from '../../../types/Response';
 import { MatchPositionType } from '../../../types/Match';
 import { makeAPIPath } from '../../../utils/utils';
@@ -117,16 +117,14 @@ const GameMainPage = () => {
 };
 
 const GamePage = () => (
-  <GameContextProvider>
-    <Switch>
-      <Route exact path={MAIN_GAME_PAGE} component={GameMainPage} />
-      <Route exact path={PLAY_PATH} component={GamePlayPage} />
-      <Route path={WATCH_PATH} component={GameWatchPage} />
-      <Route exact path="/">
-        <Redirect to={MAIN_GAME_PAGE} />
-      </Route>
-    </Switch>
-  </GameContextProvider>
+  <Switch>
+    <Route exact path={MAIN_GAME_PAGE} component={GameMainPage} />
+    <Route exact path={PLAY_PATH} component={GamePlayPage} />
+    <Route path={WATCH_PATH} component={GameWatchPage} />
+    <Route exact path="/">
+      <Redirect to={MAIN_GAME_PAGE} />
+    </Route>
+  </Switch>
 );
 
 export default GamePage;

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -61,7 +61,7 @@ const GameMainPage = () => {
   };
 
   const handleExit = () => {
-    socket?.emit('leaveGame');
+    socket?.emit('leaveGame', { type: 'LADDER', mode });
     gameDispatch({ type: 'setMode', mode: null });
   };
 

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -50,6 +50,7 @@ const GameMainPage = () => {
   const handleDuplicated = () => {
     toast.warn('자신과 매칭되어 대기를 취소합니다.');
     gameDispatch({ type: 'reset' });
+    setOpen(false);
   };
 
   const changeMode = (gameMode: GameModeType) => {
@@ -62,8 +63,8 @@ const GameMainPage = () => {
     setDialog({
       ...dialog,
       title: `${gameMode} MODE matching...`,
-      buttons: <Button onClick={handleExit}>매칭 취소</Button>,
-      onClose: handleExit,
+      buttons: <Button onClick={() => handleExit(gameMode)}>매칭 취소</Button>,
+      onClose: () => handleExit(gameMode),
     });
     socket?.on('ready', handleReady);
     socket?.on('duplicated', handleDuplicated);
@@ -72,7 +73,7 @@ const GameMainPage = () => {
   };
 
   useEffect(() => {
-    if (mode) handleExit();
+    if (mode) handleExit(mode);
     setDialog({
       title: 'default',
       content: (
@@ -81,8 +82,8 @@ const GameMainPage = () => {
           <Typo variant="subtitle1" align="center">매칭 가능한 유저를 찾는 중입니다</Typo>
         </Grid>
       ),
-      buttons: <Button onClick={handleExit}>매칭 취소</Button>,
-      onClose: handleExit,
+      buttons: <Button onClick={() => handleExit(mode)}>매칭 취소</Button>,
+      onClose: () => handleExit(mode),
     });
 
     return () => {

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -14,6 +14,7 @@ import Dialog from '../../molecules/Dialog/Dialog';
 import Typo from '../../atoms/Typo/Typo';
 import GamePlayPage from '../GamePlayPage/GamePlayPage';
 import { GameContextProvider, useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
+import { RawUserInfoType } from '../../../types/Response';
 
 const MAIN_GAME_PAGE = '/game';
 const PLAY_PATH = '/game/play';
@@ -42,7 +43,9 @@ const GameMainPage = () => {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
 
-  const handleReady = (position: 'LEFT' | 'RIGHT', setting: any) => {
+  const handleReady = (position: 'LEFT' | 'RIGHT', player0: RawUserInfoType, player1: RawUserInfoType, setting: any) => {
+    // eslint-disable-next-line no-console
+    console.log(player0, player1);
     gameDispatch({ type: 'ready', setting, position });
     socket?.off('ready');
     setOpen(false);

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -15,7 +15,7 @@ import Typo from '../../atoms/Typo/Typo';
 import GamePlayPage from '../GamePlayPage/GamePlayPage';
 import { useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
 import { RawUserInfoType } from '../../../types/Response';
-import { MatchPositionType } from '../../../types/Match';
+import { MatchPositionType, GameModeType } from '../../../types/Match';
 import { makeAPIPath } from '../../../utils/utils';
 
 const MAIN_GAME_PAGE = '/game';
@@ -65,6 +65,15 @@ const GameMainPage = () => {
     gameDispatch({ type: 'reset' });
   };
 
+  const changeMode = (gameMode: GameModeType) => {
+    gameDispatch({
+      type: 'setGame',
+      gameType: 'LADDER',
+      mode: gameMode,
+      isPlayer: true,
+    });
+  };
+
   useEffect(() => {
     if (!mode) {
       socket?.off('ready');
@@ -106,13 +115,13 @@ const GameMainPage = () => {
         onClose={dialog.onClose}
       />
       <Grid item xs={6}>
-        <GameOptionCard option="CLASSIC" onClick={() => gameDispatch({ type: 'setMode', mode: 'CLASSIC' })} />
+        <GameOptionCard option="CLASSIC" onClick={() => changeMode('CLASSIC')} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="SPEED" onClick={() => gameDispatch({ type: 'setMode', mode: 'SPEED' })} />
+        <GameOptionCard option="SPEED" onClick={() => changeMode('SPEED')} />
       </Grid>
       <Grid item xs={6}>
-        <GameOptionCard option="REVERSE" onClick={() => gameDispatch({ type: 'setMode', mode: 'REVERSE' })} />
+        <GameOptionCard option="REVERSE" onClick={() => changeMode('REVERSE')} />
       </Grid>
       <Grid item xs={6}>
         <GameOptionCard option="WATCH" onClick={() => { history.push(WATCH_PATH); }} />

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -49,6 +49,11 @@ const GameMainPage = () => {
     history.push(PLAY_PATH);
   };
 
+  const handleExit = () => {
+    socket?.emit('leaveGame');
+    gameDispatch({ type: 'setMode', mode: null });
+  };
+
   useEffect(() => {
     if (!mode) {
       socket?.off('ready');
@@ -70,8 +75,8 @@ const GameMainPage = () => {
           <Typo variant="subtitle1" align="center">매칭 가능한 유저를 찾는 중입니다</Typo>
         </Grid>
       ),
-      buttons: <Button onClick={() => gameDispatch({ type: 'setMode', mode: null })}>매칭 취소</Button>,
-      onClose: () => gameDispatch({ type: 'setMode', mode: null }),
+      buttons: <Button onClick={handleExit}>매칭 취소</Button>,
+      onClose: handleExit,
     });
   }, []);
 

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import {
   Route, Switch, useHistory, Redirect,
 } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -45,6 +46,11 @@ const GameMainPage = () => {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
 
+  const handleDuplicated = () => {
+    toast.warn('자신과 매칭되어 대기를 취소합니다.');
+    gameDispatch({ type: 'reset' });
+  };
+
   const handleReady = (
     position: MatchPositionType, player0: RawUserInfoType, player1: RawUserInfoType, setting: any,
   ) => {
@@ -56,6 +62,7 @@ const GameMainPage = () => {
       setting,
     });
     socket?.off('ready');
+    socket?.off('duplicated');
     setOpen(false);
     history.push(PLAY_PATH);
   };
@@ -77,6 +84,7 @@ const GameMainPage = () => {
   useEffect(() => {
     if (!mode) {
       socket?.off('ready');
+      socket?.off('duplicated');
       setOpen(false);
     } else {
       setDialog({
@@ -86,6 +94,7 @@ const GameMainPage = () => {
         onClose: handleExit,
       });
       socket?.on('ready', handleReady);
+      socket?.on('duplicated', handleDuplicated);
       setOpen(true);
       socket?.emit('waiting', { type: 'LADDER', mode });
     }
@@ -103,6 +112,11 @@ const GameMainPage = () => {
       buttons: <Button onClick={handleExit}>매칭 취소</Button>,
       onClose: handleExit,
     });
+
+    return () => {
+      socket?.off('ready');
+      socket?.off('duplicated');
+    };
   }, []);
 
   return (

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -62,7 +62,7 @@ const GameMainPage = () => {
 
   const handleExit = () => {
     socket?.emit('leaveGame', { type: 'LADDER', mode });
-    gameDispatch({ type: 'setMode', mode: null });
+    gameDispatch({ type: 'reset' });
   };
 
   useEffect(() => {
@@ -70,7 +70,12 @@ const GameMainPage = () => {
       socket?.off('ready');
       setOpen(false);
     } else {
-      setDialog({ ...dialog, title: `${mode} MODE matching...` });
+      setDialog({
+        ...dialog,
+        title: `${mode} MODE matching...`,
+        buttons: <Button onClick={handleExit}>매칭 취소</Button>,
+        onClose: handleExit,
+      });
       socket?.on('ready', handleReady);
       setOpen(true);
       socket?.emit('waiting', { type: 'LADDER', mode });

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -15,9 +15,8 @@ import Dialog from '../../molecules/Dialog/Dialog';
 import Typo from '../../atoms/Typo/Typo';
 import GamePlayPage from '../GamePlayPage/GamePlayPage';
 import { useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
-import { RawUserInfoType } from '../../../types/Response';
-import { MatchPositionType, GameModeType } from '../../../types/Match';
-import { makeAPIPath } from '../../../utils/utils';
+import useMatch from '../../../utils/hooks/useMatch';
+import { GameModeType } from '../../../types/Match';
 
 const MAIN_GAME_PAGE = '/game';
 const PLAY_PATH = '/game/play';
@@ -46,37 +45,11 @@ const GameMainPage = () => {
   const {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
+  const { handleReady, handleExit } = useMatch(setOpen, setDialog);
 
   const handleDuplicated = () => {
     toast.warn('자신과 매칭되어 대기를 취소합니다.');
     gameDispatch({ type: 'reset' });
-  };
-
-  const handleReady = (
-    position: MatchPositionType,
-    player0: RawUserInfoType,
-    player1: RawUserInfoType,
-    gameSetting: any,
-  ) => {
-    gameDispatch({
-      type: 'ready',
-      position,
-      player0: { ...player0, avatar: makeAPIPath(`/${player0.avatar}`) },
-      player1: { ...player1, avatar: makeAPIPath(`/${player1.avatar}`) },
-      setting: gameSetting,
-    });
-    socket?.off('ready');
-    socket?.off('duplicated');
-    setOpen(false);
-    history.push(PLAY_PATH);
-  };
-
-  const handleExit = () => {
-    socket?.emit('leaveGame', { type: 'LADDER', mode });
-    gameDispatch({ type: 'reset' });
-    socket?.off('ready');
-    socket?.off('duplicated');
-    setOpen(false);
   };
 
   const changeMode = (gameMode: GameModeType) => {

--- a/src/components/pages/GamePage/GamePage.tsx
+++ b/src/components/pages/GamePage/GamePage.tsx
@@ -73,7 +73,7 @@ const GameMainPage = () => {
       setDialog({ ...dialog, title: `${mode} MODE matching...` });
       socket?.on('ready', handleReady);
       setOpen(true);
-      socket?.emit('waiting');
+      socket?.emit('waiting', 'LADDER', mode);
     }
   }, [mode]);
 

--- a/src/components/pages/GamePlayPage/GamePage.stories.tsx
+++ b/src/components/pages/GamePlayPage/GamePage.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { BrowserRouter } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import GamePlayPage from './GamePlayPage';
+import MainTemplate from '../../templates/MainTemplate/MainTemplate';
+import ContextProvider from '../../../utils/hooks/useContext';
+
+export default {
+  title: 'Pages/GamePlayPage',
+  component: GamePlayPage,
+} as Meta;
+
+const useStyles = makeStyles({
+  div: {
+    backgroundColor: 'lightgray',
+    width: '100%',
+    height: '100%',
+  },
+});
+
+export const WithMainTemplate = () => {
+  const classes = useStyles();
+
+  return (
+    <BrowserRouter>
+      <ContextProvider>
+        <MainTemplate
+          main={<GamePlayPage />}
+          chat={<div className={classes.div}>chat. 배경색은 스토리에서 적용한 것입니다!</div>}
+        />
+      </ContextProvider>
+    </BrowserRouter>
+  );
+};

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -119,7 +119,7 @@ const GamePlayPage = () => {
     });
 
     return () => {
-      socket?.emit('leaveGame', { type: 'LADDER', mode }); // FIXME LADDER가 아닌 경우
+      if (mode) socket?.emit('leaveGame', { type: 'LADDER', mode }); // FIXME LADDER가 아닌 경우
       setOpen(false);
       gameDispatch({ type: 'reset' });
       socket?.off('update');

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -77,6 +77,12 @@ const GamePlayPage = () => {
     }
   };
 
+  const handleExit = () => {
+    socket?.emit('leaveGame', { type: gameType, mode });
+    if (isPlayer) setState('end');
+    else history.goBack();
+  };
+
   useEffect(() => {
     if (!setting || !position || !mode) {
       toast.error('잘못된 접근입니다.');
@@ -85,7 +91,8 @@ const GamePlayPage = () => {
     if (isPlayer) {
       document.addEventListener('keydown', handleKeyDown);
       document.addEventListener('keyup', handleKeyUp);
-    }
+    } else setState('playing');
+
     if (canvas.current) canvasManager.current = new CanvasManager(canvas.current.getContext('2d')!, setting);
 
     socket?.on('playing', () => setState('playing'));
@@ -160,7 +167,7 @@ const GamePlayPage = () => {
             <Typo variant="h6">{mode}</Typo>
             <Grid item container justifyContent="center" alignItems="center">
               {isPlayer && <Button onClick={() => { if (socket?.emit('ready')) setState('ready'); }} disabled={state !== 'init'}>ready</Button>}
-              <Button onClick={() => { if (socket?.emit('leaveGame', { type: gameType, mode })) setState('end'); }}>exit</Button>
+              <Button onClick={handleExit}>exit</Button>
             </Grid>
           </Grid>
           <Grid item xs={4} container justifyContent="flex-start">

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -31,7 +31,7 @@ const initialPlayerState = { score: 0, ready: false };
 const makeCountString = (count: number, state: PlayStateType): string => {
   switch (state) {
     case 'init':
-      if (count) return `${count}초 안에 ready 버튼을 누르세요.`;
+      if (count > 0) return `${count}초 안에 ready 버튼을 누르세요.`;
       return '준비 가능 시간을 초과하였습니다.';
     case 'ready':
       return '상대 플레이어가 준비되기를 기다리고 있습니다.';
@@ -102,8 +102,12 @@ const GamePlayPage = () => {
 
     socket?.on('destroy', (message) => {
       const handleClose = () => {
+        gameDispatch({ type: 'reset' });
+        socket?.emit('leaveGame');
         history.goBack();
       };
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
       setState('end');
       setDialog({
         content: message || '게임이 종료되었습니다.',
@@ -114,7 +118,7 @@ const GamePlayPage = () => {
     });
 
     return () => {
-      if (![playerState[0].score, playerState[1].score].includes(5)) socket?.emit('leaveGame');
+      socket?.emit('leaveGame');
       setOpen(false);
       gameDispatch({ type: 'reset' });
       socket?.off('update');

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -80,13 +80,13 @@ const GamePlayPage = () => {
   const handleExit = () => {
     socket?.emit('leaveGame', { type: gameType, mode });
     if (isPlayer) setState('end');
-    else history.goBack();
+    else history.replace('/');
   };
 
   useEffect(() => {
     if (!setting || !position || !mode) {
       toast.error('잘못된 접근입니다.');
-      history.goBack();
+      history.replace('/');
     }
     if (isPlayer) {
       document.addEventListener('keydown', handleKeyDown);
@@ -114,7 +114,7 @@ const GamePlayPage = () => {
     socket?.on('destroy', (message) => {
       const handleClose = () => {
         gameDispatch({ type: 'reset' });
-        history.goBack();
+        history.replace('/');
       };
       if (isPlayer) {
         document.removeEventListener('keydown', handleKeyDown);

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -148,7 +148,7 @@ const GamePlayPage = () => {
         <canvas width={setting.WIDTH} height={setting.HEIGHT} ref={canvas} />
         <Grid item container direction="row" className={classes.root} justifyContent="space-around" alignItems="center">
           <Grid item xs={4} container justifyContent="flex-end">
-            <PlayerProfile userGameInfo={{ ...player0!, win: 0, lose: 0 }} />
+            <PlayerProfile userGameInfo={player0!} />
           </Grid>
           <Grid item container xs={4} direction="column" justifyContent="center" alignItems="center">
             <Typo variant="h6">{mode}</Typo>
@@ -159,9 +159,8 @@ const GamePlayPage = () => {
             </Grid>
           </Grid>
           <Grid item xs={4} container justifyContent="flex-start">
-            <PlayerProfile userGameInfo={{ ...player1!, win: 0, lose: 0 }} />
+            <PlayerProfile userGameInfo={player1!} />
           </Grid>
-          {/* FIXME: win, lose 정보 수정 */}
         </Grid>
       </Grid>
     </>

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -176,7 +176,11 @@ const GamePlayPage = () => {
         </Grid>
       </Grid>
     </>
-  ) : <></>;
+  ) : (
+    <Grid container justifyContent="center" alignItems="center">
+      <Typo>문제가 발생했습니다.</Typo>
+    </Grid>
+  );
 };
 
 export default GamePlayPage;

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -1,24 +1,65 @@
 import Grid from '@material-ui/core/Grid';
+import { makeStyles } from '@material-ui/core/styles';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { GameModeType } from '../../../types/Match';
 import CanvasManager, { RectangleType } from '../../../utils/game/CanvasManager';
 import { useAppState } from '../../../utils/hooks/useAppContext';
+import useDialog from '../../../utils/hooks/useDialog';
+import { useGameDispatch, useGameState } from '../../../utils/hooks/useGameContext';
+import Button from '../../atoms/Button/Button';
 import Typo from '../../atoms/Typo/Typo';
+import Dialog from '../../molecules/Dialog/Dialog';
 
-type GamePlayPageProps = {
-  position: 'LEFT' | 'RIGHT' | null,
-  mode: GameModeType | null,
-  setting: any,
+type StyleProps = { width: number };
+
+const useStyles = makeStyles({
+  root: {
+    width: ({ width }: StyleProps) => width || '100%',
+  },
+});
+
+type PlayStateType = 'init' | 'ready' | 'playing' | 'end';
+
+type PlayerStateType = {
+  score: number,
+  ready: boolean,
 };
 
-const GamePlayPage = ({ position, mode, setting }: GamePlayPageProps) => {
+const initialPlayerState = { score: 0, ready: false };
+
+const makeCountString = (count: number, state: PlayStateType): string => {
+  switch (state) {
+    case 'init':
+      if (count) return `${count}초 안에 ready 버튼을 누르세요.`;
+      return '준비 가능 시간을 초과하였습니다.';
+    case 'ready':
+      return '상대 플레이어가 준비되기를 기다리고 있습니다.';
+    case 'playing':
+      if (count > 0) return `게임 시작까지 ${count}초`;
+      return 'GAME START!';
+    case 'end':
+    default:
+      if (count > 0) return `게임 종료까지 ${count}초`;
+      return 'GAME END';
+  }
+};
+
+const GamePlayPage = () => {
   const { socket } = useAppState();
   const history = useHistory();
+  const { mode, setting, position } = useGameState();
+  const gameDispatch = useGameDispatch();
+  const [state, setState] = useState<PlayStateType>('init');
   const [countdown, setCountDown] = useState<number | null>(null);
+  const [playerState, setPlayerState] = useState<
+    PlayerStateType[]>([initialPlayerState, initialPlayerState]);
   const canvas = React.createRef<HTMLCanvasElement>();
   const canvasManager = useRef<CanvasManager>();
+  const classes = useStyles(setting?.WIDTH);
+  const {
+    isOpen, setOpen, dialog, setDialog,
+  } = useDialog();
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
@@ -41,7 +82,9 @@ const GamePlayPage = ({ position, mode, setting }: GamePlayPageProps) => {
     }
     document.addEventListener('keydown', handleKeyDown);
     document.addEventListener('keyup', handleKeyUp);
-    canvasManager.current = new CanvasManager(canvas!.current!.getContext('2d')!, setting);
+    if (canvas.current) canvasManager.current = new CanvasManager(canvas.current.getContext('2d')!, setting);
+
+    socket?.on('playing', () => setState('playing'));
 
     socket?.on('update', (data) => {
       canvasManager.current?.drawBackground();
@@ -51,23 +94,63 @@ const GamePlayPage = ({ position, mode, setting }: GamePlayPageProps) => {
       canvasManager.current?.drawRect(data.player0 as RectangleType);
       canvasManager.current?.drawRect(data.player1 as RectangleType);
       setCountDown(data.countdown?.left || null);
+      setPlayerState([
+        { score: data.player0.score, ready: data.player0.ready },
+        { score: data.player1.score, ready: data.player1.ready },
+      ]);
     });
 
-    socket?.on('destroy', () => {
+    socket?.on('destroy', (message) => {
+      const handleClose = () => {
+        history.goBack();
+      };
+      setState('end');
+      setDialog({
+        content: message || '게임이 종료되었습니다.',
+        buttons: <Button onClick={handleClose}>Exit</Button>,
+        onClose: handleClose,
+      });
+      setOpen(true);
     });
 
     return () => {
+      if (![playerState[0].score, playerState[1].score].includes(5)) socket?.emit('leaveGame');
+      setOpen(false);
+      gameDispatch({ type: 'reset' });
+      socket?.off('update');
+      socket?.off('destroy');
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('keyup', handleKeyUp);
     };
   }, []);
 
   return setting ? (
-    <Grid container direction="column" justifyContent="center" alignItems="center">
-      <Typo variant="h6">{countdown || 'GO!'}</Typo>
-      <Typo variant="subtitle1">{position === 'LEFT' ? '< YOU' : 'YOU >'}</Typo>
-      <canvas width={setting.WIDTH} height={setting.HEIGHT} ref={canvas} />
-    </Grid>
+    <>
+      <Dialog
+        isOpen={isOpen}
+        title={dialog.title}
+        content={dialog.content}
+        buttons={dialog.buttons}
+        onClose={dialog.onClose}
+      />
+      <Grid container className={classes.root} direction="column" justifyContent="center" alignItems="center">
+        <Grid item container justifyContent="center" alignItems="center">
+          <Button onClick={() => { if (socket?.emit('ready')) setState('ready'); }} disabled={state !== 'init'}>ready</Button>
+          <Button onClick={() => { if (socket?.emit('leaveGame')) setState('end'); }}>exit</Button>
+        </Grid>
+        <Typo variant="h6">{mode}</Typo>
+        <Typo variant="h5">{makeCountString(countdown || 0, [playerState[0].score, playerState[1].score].includes(5) ? 'end' : state)}</Typo>
+        <Grid item container justifyContent="space-evenly" alignItems="center">
+          <Typo variant="h6">{playerState[0].score}</Typo>
+          <Typo variant="body1">SCORE</Typo>
+          <Typo variant="h6">{playerState[1].score}</Typo>
+        </Grid>
+        <canvas width={setting.WIDTH} height={setting.HEIGHT} ref={canvas} />
+        <Grid item container className={classes.root} justifyContent={position === 'LEFT' ? 'flex-start' : 'flex-end'} alignItems="center">
+          <Typo variant="h6">YOU</Typo>
+        </Grid>
+      </Grid>
+    </>
   ) : <></>;
 };
 

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -119,7 +119,7 @@ const GamePlayPage = () => {
     });
 
     return () => {
-      socket?.emit('leaveGame');
+      socket?.emit('leaveGame', { type: 'LADDER', mode }); // FIXME LADDER가 아닌 경우
       setOpen(false);
       gameDispatch({ type: 'reset' });
       socket?.off('update');
@@ -154,7 +154,8 @@ const GamePlayPage = () => {
             <Typo variant="h6">{mode}</Typo>
             <Grid item container justifyContent="center" alignItems="center">
               <Button onClick={() => { if (socket?.emit('ready')) setState('ready'); }} disabled={state !== 'init'}>ready</Button>
-              <Button onClick={() => { if (socket?.emit('leaveGame')) setState('end'); }}>exit</Button>
+              <Button onClick={() => { if (socket?.emit('leaveGame', { type: 'LADDER', mode })) setState('end'); }}>exit</Button>
+              {/* FIXME LADDER가 아닌 경우 */}
             </Grid>
           </Grid>
           <Grid item xs={4} container justifyContent="flex-start">

--- a/src/components/pages/GamePlayPage/GamePlayPage.tsx
+++ b/src/components/pages/GamePlayPage/GamePlayPage.tsx
@@ -1,0 +1,74 @@
+import Grid from '@material-ui/core/Grid';
+import React, { useEffect, useRef, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { toast } from 'react-toastify';
+import { GameModeType } from '../../../types/Match';
+import CanvasManager, { RectangleType } from '../../../utils/game/CanvasManager';
+import { useAppState } from '../../../utils/hooks/useAppContext';
+import Typo from '../../atoms/Typo/Typo';
+
+type GamePlayPageProps = {
+  position: 'LEFT' | 'RIGHT' | null,
+  mode: GameModeType | null,
+  setting: any,
+};
+
+const GamePlayPage = ({ position, mode, setting }: GamePlayPageProps) => {
+  const { socket } = useAppState();
+  const history = useHistory();
+  const [countdown, setCountDown] = useState<number | null>(null);
+  const canvas = React.createRef<HTMLCanvasElement>();
+  const canvasManager = useRef<CanvasManager>();
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
+      e.preventDefault();
+      socket?.emit('keydown', e.code === 'ArrowUp' ? 38 : 40);
+    }
+  };
+
+  const handleKeyUp = (e: KeyboardEvent) => {
+    if (e.code === 'ArrowUp' || e.code === 'ArrowDown') {
+      e.preventDefault();
+      socket?.emit('keyup', e.code === 'ArrowUp' ? 38 : 40);
+    }
+  };
+
+  useEffect(() => {
+    if (!setting || !position || !mode) {
+      toast.error('잘못된 접근입니다.');
+      history.goBack();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+    canvasManager.current = new CanvasManager(canvas!.current!.getContext('2d')!, setting);
+
+    socket?.on('update', (data) => {
+      canvasManager.current?.drawBackground();
+      canvasManager.current?.drawNet();
+      canvasManager.current?.drawBorder();
+      canvasManager.current?.drawRect(data.ball as RectangleType);
+      canvasManager.current?.drawRect(data.player0 as RectangleType);
+      canvasManager.current?.drawRect(data.player1 as RectangleType);
+      setCountDown(data.countdown?.left || null);
+    });
+
+    socket?.on('destroy', () => {
+    });
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
+
+  return setting ? (
+    <Grid container direction="column" justifyContent="center" alignItems="center">
+      <Typo variant="h6">{countdown || 'GO!'}</Typo>
+      <Typo variant="subtitle1">{position === 'LEFT' ? '< YOU' : 'YOU >'}</Typo>
+      <canvas width={setting.WIDTH} height={setting.HEIGHT} ref={canvas} />
+    </Grid>
+  ) : <></>;
+};
+
+export default GamePlayPage;

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -79,7 +79,7 @@ const MatchList = ({ type }: ListProps) => {
           leftUser={match.user1}
           rightUser={match.user2}
           mode={match.mode}
-          onClick={() => {}}
+          onClick={() => {}} // FIXME: 소켓 이벤트 확정시 관전 로직 추가
         />
       ))}
       {!isListEnd && (

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -22,7 +22,7 @@ type ListProps = {
 const MatchList = ({ type }: ListProps) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
-  const path = makeAPIPath('/matches/spectating');
+  const path = makeAPIPath('/matches?status=IN_PROGRESS');
   const typePath = type === 'ALL' ? '' : `&type=${type}`;
   const [matches, setMatches] = useState<MatchType[]>([]);
   const [isListEnd, setListEnd] = useState(true);
@@ -31,7 +31,7 @@ const MatchList = ({ type }: ListProps) => {
   const fetchItems = () => {
     if (isListEnd) return;
 
-    asyncGetRequest(`${path}?perPage=${COUNTS_PER_PAGE}&page=${page}${typePath}`, source)
+    asyncGetRequest(`${path}&perPage=${COUNTS_PER_PAGE}&page=${page}${typePath}`, source)
       .then(({ data }: { data: RawMatchType[] }) => {
         const typed: MatchType[] = data.map((match) => ({
           ...match,

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import Grid from '@material-ui/core/Grid';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import {
+  Redirect, Route, Switch, useLocation,
+} from 'react-router-dom';
 import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
 import { RawMatchType, MatchType, GameModeType } from '../../../types/Match';
 import List from '../../atoms/List/List';
@@ -141,20 +143,23 @@ const list = [
   { name: 'EXHIBITION', link: EXHIBITION_MATCH_PATH },
 ];
 
-const GameWatchPage = () => (
-  <>
-    <SubMenu current={window.location.pathname} list={list} />
-    <List height="78vh" scroll>
-      <Switch>
-        <Route exact path={ALL_MATCH_PATH} component={AllMatchList} />
-        <Route exact path={LADDER_MATCH_PATH} component={LadderList} />
-        <Route exact path={EXHIBITION_MATCH_PATH} component={ExhibitionList} />
-        <Route path="/">
-          <Redirect to={ALL_MATCH_PATH} />
-        </Route>
-      </Switch>
-    </List>
-  </>
-);
+const GameWatchPage = () => {
+  const location = useLocation();
+  return (
+    <>
+      <SubMenu current={location.pathname} list={list} />
+      <List height="78vh" scroll>
+        <Switch>
+          <Route exact path={ALL_MATCH_PATH} component={AllMatchList} />
+          <Route exact path={LADDER_MATCH_PATH} component={LadderList} />
+          <Route exact path={EXHIBITION_MATCH_PATH} component={ExhibitionList} />
+          <Route path="/">
+            <Redirect to={ALL_MATCH_PATH} />
+          </Route>
+        </Switch>
+      </List>
+    </>
+  );
+};
 
 export default GameWatchPage;

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -39,7 +39,7 @@ const MatchList = ({ type }: ListProps) => {
   const [page, setPage] = useState<number>(0);
 
   const handleWatch = (matchId: string) => {
-    socket?.emit('watchMatch', matchId);
+    socket?.emit('watchMatch', { id: matchId });
     socket?.on('ready', handleReady);
   };
 

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -8,7 +8,9 @@ import List from '../../atoms/List/List';
 import SubMenu from '../../molecules/SubMenu/SubMenu';
 import useIntersect from '../../../utils/hooks/useIntersect';
 import GameListItem, { GameListItemSkeleton } from '../../organisms/GameListItem/GameListItem';
-import { useAppDispatch, useAppState } from '../../../utils/hooks/useAppContext';
+import { useAppState } from '../../../utils/hooks/useAppContext';
+import useMatch from '../../../utils/hooks/useMatch';
+import { DialogProps } from '../../../utils/hooks/useDialog';
 
 const ALL_MATCH_PATH = '/game/watch/all';
 const LADDER_MATCH_PATH = '/game/watch/ladder';
@@ -20,28 +22,25 @@ type ListProps = {
   type: 'ALL' | 'LADDER' | 'EXHIBITION',
 }
 
+// eslint-disable-next-line no-unused-vars
+const dummySetOpen = (value: boolean) => {};
+// eslint-disable-next-line no-unused-vars
+const dummySetDialog = (value: DialogProps) => {};
+
 const MatchList = ({ type }: ListProps) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
   const path = makeAPIPath('/matches?status=IN_PROGRESS');
   const typePath = type === 'ALL' ? '' : `&type=${type}`;
-  const appDispatch = useAppDispatch();
   const { socket } = useAppState();
+  const { handleReady } = useMatch(dummySetOpen, dummySetDialog);
   const [matches, setMatches] = useState<MatchType[]>([]);
   const [isListEnd, setListEnd] = useState(true);
   const [page, setPage] = useState<number>(0);
 
   const handleWatch = (matchId: string) => {
     socket?.emit('watchMatch', matchId);
-    appDispatch({ type: 'loading' });
-    // FIXME: 본 함수 아래 부분은 서버->클라이언트 이벤트를 받지 않으면
-    //        로딩이 끝나지 않는 문제를 해결하려고 넣었습니다. 추후 수정 예정입니다.
-    // TODO: socket?.on('이벤트명', () => {
-    //   socket?.off('이벤트명');
-    // });
-    setTimeout(() => {
-      appDispatch({ type: 'endLoading' });
-    }, 3000);
+    socket?.on('ready', handleReady);
   };
 
   const fetchItems = () => {
@@ -81,7 +80,7 @@ const MatchList = ({ type }: ListProps) => {
     setListEnd(false);
 
     return () => {
-      // TODO: socket?.off
+      socket?.off('ready');
       source.cancel();
       setMatches([]);
       setListEnd(true);

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import Grid from '@material-ui/core/Grid';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { asyncGetRequest, errorMessageHandler, makeAPIPath } from '../../../utils/utils';
-import { RawMatchType, MatchType } from '../../../types/Match';
+import { RawMatchType, MatchType, GameModeType } from '../../../types/Match';
 import List from '../../atoms/List/List';
 import SubMenu from '../../molecules/SubMenu/SubMenu';
 import useIntersect from '../../../utils/hooks/useIntersect';
@@ -11,6 +11,7 @@ import GameListItem, { GameListItemSkeleton } from '../../organisms/GameListItem
 import { useAppState } from '../../../utils/hooks/useAppContext';
 import useMatch from '../../../utils/hooks/useMatch';
 import { DialogProps } from '../../../utils/hooks/useDialog';
+import { useGameDispatch } from '../../../utils/hooks/useGameContext';
 
 const ALL_MATCH_PATH = '/game/watch/all';
 const LADDER_MATCH_PATH = '/game/watch/ladder';
@@ -33,12 +34,19 @@ const MatchList = ({ type }: ListProps) => {
   const path = makeAPIPath('/matches?status=IN_PROGRESS');
   const typePath = type === 'ALL' ? '' : `&type=${type}`;
   const { socket } = useAppState();
+  const gameDispatch = useGameDispatch();
   const { handleReady } = useMatch(dummySetOpen, dummySetDialog);
   const [matches, setMatches] = useState<MatchType[]>([]);
   const [isListEnd, setListEnd] = useState(true);
   const [page, setPage] = useState<number>(0);
 
-  const handleWatch = (matchId: string) => {
+  const handleWatch = (mode: GameModeType, matchId: string) => {
+    gameDispatch({
+      type: 'setGame',
+      mode,
+      gameType: 'EXHIBITION',
+      isPlayer: false,
+    });
     socket?.emit('watchMatch', { id: matchId });
     socket?.on('ready', handleReady);
   };
@@ -95,7 +103,7 @@ const MatchList = ({ type }: ListProps) => {
           leftUser={match.user1}
           rightUser={match.user2}
           mode={match.mode}
-          onClick={() => handleWatch(match.id)}
+          onClick={() => handleWatch(match.mode, match.id)}
         />
       ))}
       {!isListEnd && (

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -176,7 +176,9 @@ const AchievementList = ({ username }: UserNameType) => {
 };
 
 const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
-  const [user, setUser] = useState<RelatedInfoType>(initialUserInfo);
+  const { CancelToken } = axios;
+  const source = CancelToken.source();
+  const [user, setUser] = useState<RelatedInfoType | null>(initialUserInfo);
   const {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
@@ -191,16 +193,17 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
       friendship: initialRawFriendInfo,
     };
     appDispatch({ type: 'loading' });
-    asyncGetRequest(makeAPIPath(`/users/${username}`))
+    asyncGetRequest(makeAPIPath(`/users/${username}`), source)
       .then(({ data }) => {
         Object.assign(userInfo, data);
         return (
-          asyncGetRequest(makeAPIPath(`/friendships/${username}`))
+          asyncGetRequest(makeAPIPath(`/friendships/${username}`), source)
             .then((response) => {
               Object.assign(userInfo.friendship, response.data);
               setUser(makeRelatedInfo(me, userInfo));
             })
             .catch((error) => {
+              source.cancel();
               if (error.response && [404, 409].includes(error.response.status)) {
                 userInfo.friendship = null;
                 setUser(makeRelatedInfo(me, userInfo));
@@ -208,6 +211,7 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
             }));
       })
       .catch((error) => {
+        source.cancel();
         if (error.response && error.response.status >= 400 && error.response.status < 500) {
           history.push('/404');
         } else {
@@ -217,9 +221,14 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
       .finally(() => {
         appDispatch({ type: 'endLoading' });
       });
-  }, []);
 
-  return (
+    return () => {
+      source.cancel();
+      setUser(null);
+    };
+  }, [username]);
+
+  return user ? (
     <>
       <Dialog
         isOpen={isOpen}
@@ -252,7 +261,7 @@ const ProfilePage = ({ match }: RouteComponentProps<MatchParams>) => {
         </Grid>
       </Grid>
     </>
-  );
+  ) : <></>;
 };
 
 export default ProfilePage;

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -41,7 +41,7 @@ type MatchParams = {
 const MatchHistory = ({ username }: UserNameType) => {
   const { CancelToken } = axios;
   const source = CancelToken.source();
-  const path = makeAPIPath(`/matches/${username}`);
+  const path = makeAPIPath(`/users/${username}/matches`);
   const [matchHistories, setMatchHistories] = useState<MatchType[]>([]);
   const [isListEnd, setListEnd] = useState(true);
   const [page, setPage] = useState<number>(0);

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -7,7 +7,7 @@ export type MatchGameType = 'LADDER' | 'EXHIBITION';
 
 export type GameModeType = 'CLASSIC' | 'SPEED' | 'REVERSE';
 
-export type MatchPositionType = 'LEFT' | 'RIGHT';
+export type MatchPositionType = 'LEFT' | 'RIGHT' | 'WATCH';
 
 export type RawMatchType = {
   id: string,

--- a/src/types/Match.ts
+++ b/src/types/Match.ts
@@ -7,6 +7,8 @@ export type MatchGameType = 'LADDER' | 'EXHIBITION';
 
 export type GameModeType = 'CLASSIC' | 'SPEED' | 'REVERSE';
 
+export type MatchPositionType = 'LEFT' | 'RIGHT';
+
 export type RawMatchType = {
   id: string,
   createdAt: string,

--- a/src/types/Response.ts
+++ b/src/types/Response.ts
@@ -16,6 +16,9 @@ export type RawUserInfoType = {
   enable2FA: boolean,
   authenticatorSecret: boolean,
   isSecondFactorAuthenticated: boolean,
+  win?: number,
+  lose?: number,
+  score?: number,
 };
 
 export const initialRawUserInfo: RawUserInfoType = {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -40,6 +40,9 @@ export type UserInfoType = {
   name: string,
   avatar: string,
   status: UserStatusType,
+  win?: number,
+  lose?: number,
+  score?: number,
 };
 
 /**

--- a/src/utils/friendships.ts
+++ b/src/utils/friendships.ts
@@ -20,7 +20,7 @@ const makeRelationship = (isMeRequester: boolean, status: FriendshipType): Relat
 
 const makeRelatedInfo = (me: MyInfoType, rawData: RawRelatedInfoType): RelatedInfoType => {
   const {
-    id, name, avatar, status, friendship,
+    id, name, avatar, status, friendship, score, win, lose,
   } = rawData;
   const result: RelatedInfoType = {
     id,
@@ -28,6 +28,9 @@ const makeRelatedInfo = (me: MyInfoType, rawData: RawRelatedInfoType): RelatedIn
     avatar: makeAPIPath(`/${avatar}`),
     status,
     relationship: 'NONE',
+    score,
+    win,
+    lose,
   };
 
   if (!friendship) return result;

--- a/src/utils/game/CanvasManager.ts
+++ b/src/utils/game/CanvasManager.ts
@@ -1,0 +1,60 @@
+export type GameStatusType = 'none' | 'ready' | 'countdown' | 'playing' | 'gameOver';
+
+export type RectangleType = {
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  color: string,
+};
+
+export default class CanvasManager {
+  ctx: CanvasRenderingContext2D;
+
+  settings;
+
+  constructor(ctx: CanvasRenderingContext2D, settings: any) { // FIXME: setting type
+    this.ctx = ctx;
+    this.settings = settings;
+  }
+
+  drawRect(rect: RectangleType): void {
+    if (!rect.color) return;
+    this.ctx.save();
+    this.ctx.beginPath();
+
+    this.ctx.globalAlpha = 1;
+    if (rect.color) {
+      this.ctx.fillStyle = rect.color;
+      this.ctx.fillRect(rect.x - rect.width / 2, rect.y - rect.height / 2, rect.width, rect.height);
+    }
+    this.ctx.restore();
+  }
+
+  drawBackground(): void {
+    this.ctx.save();
+    this.ctx.globalAlpha = 1;
+    this.ctx.fillStyle = this.settings.BACKGROUND_COLOR;
+    this.ctx.fillRect(0, 0, this.settings.WIDTH, this.settings.HEIGHT);
+    this.ctx.restore();
+  }
+
+  drawBorder(): void {
+    this.ctx.fillStyle = '#000000';
+    this.ctx.fillRect(0, 0, this.settings.WIDTH, this.settings.BORDER_WIDTH);
+    this.ctx.fillRect(0, this.settings.HEIGHT - this.settings.BORDER_WIDTH,
+      this.settings.WIDTH, this.settings.BORDER_WIDTH);
+  }
+
+  drawNet(): void {
+    const num = 10;
+    const height = this.settings.HEIGHT / ((num + 1) * 2);
+    let y = height / 2;
+    const x = (this.settings.WIDTH - this.settings.NET.WIDTH) / 2;
+    this.ctx.fillStyle = '#000000';
+    while (y < this.settings.HEIGHT) {
+      this.ctx.fillRect(x, y, this.settings.NET.WIDTH, height);
+      y += height * 2;
+    }
+  }
+}

--- a/src/utils/game/CanvasManager.ts
+++ b/src/utils/game/CanvasManager.ts
@@ -1,5 +1,3 @@
-export type GameStatusType = 'none' | 'ready' | 'countdown' | 'playing' | 'gameOver';
-
 export type RectangleType = {
   x: number,
   y: number,
@@ -13,7 +11,7 @@ export default class CanvasManager {
 
   settings;
 
-  constructor(ctx: CanvasRenderingContext2D, settings: any) { // FIXME: setting type
+  constructor(ctx: CanvasRenderingContext2D, settings: any) {
     this.ctx = ctx;
     this.settings = settings;
   }

--- a/src/utils/hooks/useContext.tsx
+++ b/src/utils/hooks/useContext.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { AppContextProvider } from './useAppContext';
+import { GameContextProvider } from './useGameContext';
 import { UserContextProvider } from './useUserContext';
 
 export default function ContextProvider({ children }: { children: React.ReactNode }) {
   return (
     <AppContextProvider>
       <UserContextProvider>
-        {children}
+        <GameContextProvider>
+          {children}
+        </GameContextProvider>
       </UserContextProvider>
     </AppContextProvider>
   );

--- a/src/utils/hooks/useGameContext.tsx
+++ b/src/utils/hooks/useGameContext.tsx
@@ -1,23 +1,29 @@
 import React, {
   createContext, Dispatch, useContext, useReducer,
 } from 'react';
-import { GameModeType } from '../../types/Match';
+import { GameModeType, MatchPositionType } from '../../types/Match';
+import { RawUserInfoType } from '../../types/Response';
+import { UserInfoType } from '../../types/User';
 
 type GameStateType = {
   mode: GameModeType | null,
   setting: any | null,
-  position: 'LEFT' | 'RIGHT' | null,
+  player0: UserInfoType | null,
+  player1: UserInfoType | null,
+  position: MatchPositionType | null,
 };
 
 const initialGameState: GameStateType = {
   mode: null,
   setting: null,
+  player0: null,
+  player1: null,
   position: null,
 };
 
 type GameActionType =
   { type: 'setMode', mode: GameModeType | null } |
-  { type: 'ready', setting: any, position: 'LEFT' | 'RIGHT' } |
+  { type: 'ready', position: MatchPositionType, player0: RawUserInfoType, player1: RawUserInfoType, setting: any } |
   { type: 'reset' };
 
 const GameStateContext = createContext<GameStateType | undefined>(undefined);
@@ -28,7 +34,13 @@ function GameReducer(state: GameStateType, action: GameActionType): GameStateTyp
     case 'setMode':
       return { ...state, mode: action.mode };
     case 'ready':
-      return { ...state, setting: action.setting, position: action.position };
+      // eslint-disable-next-line no-case-declarations
+      const {
+        position, player0, player1, setting,
+      } = action;
+      return {
+        ...state, position, player0, player1, setting,
+      };
     case 'reset':
       return { ...initialGameState };
     default:

--- a/src/utils/hooks/useGameContext.tsx
+++ b/src/utils/hooks/useGameContext.tsx
@@ -1,12 +1,14 @@
 import React, {
   createContext, Dispatch, useContext, useReducer,
 } from 'react';
-import { GameModeType, MatchPositionType } from '../../types/Match';
+import { GameModeType, MatchGameType, MatchPositionType } from '../../types/Match';
 import { RawUserInfoType } from '../../types/Response';
 import { UserInfoType } from '../../types/User';
 
 type GameStateType = {
   mode: GameModeType | null,
+  gameType: MatchGameType | null,
+  isPlayer: boolean,
   setting: any | null,
   player0: UserInfoType | null,
   player1: UserInfoType | null,
@@ -15,6 +17,8 @@ type GameStateType = {
 
 const initialGameState: GameStateType = {
   mode: null,
+  gameType: null,
+  isPlayer: false,
   setting: null,
   player0: null,
   player1: null,
@@ -22,7 +26,7 @@ const initialGameState: GameStateType = {
 };
 
 type GameActionType =
-  { type: 'setMode', mode: GameModeType | null } |
+  { type: 'setGame', mode: GameModeType, gameType: MatchGameType, isPlayer: boolean } |
   { type: 'ready', position: MatchPositionType, player0: RawUserInfoType, player1: RawUserInfoType, setting: any } |
   { type: 'reset' };
 
@@ -31,16 +35,20 @@ const GameDispatchContext = createContext<Dispatch<GameActionType> | undefined>(
 
 function GameReducer(state: GameStateType, action: GameActionType): GameStateType {
   switch (action.type) {
-    case 'setMode':
-      return { ...state, mode: action.mode };
-    case 'ready':
-      // eslint-disable-next-line no-case-declarations
+    case 'setGame': {
+      const { mode, gameType, isPlayer } = action;
+      return {
+        ...state, mode, gameType, isPlayer,
+      };
+    }
+    case 'ready': {
       const {
         position, player0, player1, setting,
       } = action;
       return {
         ...state, position, player0, player1, setting,
       };
+    }
     case 'reset':
       return { ...initialGameState };
     default:

--- a/src/utils/hooks/useGameContext.tsx
+++ b/src/utils/hooks/useGameContext.tsx
@@ -1,0 +1,68 @@
+import React, {
+  createContext, Dispatch, useContext, useReducer,
+} from 'react';
+import { GameModeType } from '../../types/Match';
+
+type GameStateType = {
+  mode: GameModeType | null,
+  setting: any | null,
+  position: 'LEFT' | 'RIGHT' | null,
+};
+
+const initialGameState: GameStateType = {
+  mode: null,
+  setting: null,
+  position: null,
+};
+
+type GameActionType =
+  { type: 'setMode', mode: GameModeType | null } |
+  { type: 'ready', setting: any, position: 'LEFT' | 'RIGHT' } |
+  { type: 'reset' };
+
+const GameStateContext = createContext<GameStateType | undefined>(undefined);
+const GameDispatchContext = createContext<Dispatch<GameActionType> | undefined>(undefined);
+
+function GameReducer(state: GameStateType, action: GameActionType): GameStateType {
+  switch (action.type) {
+    case 'setMode':
+      return { ...state, mode: action.mode };
+    case 'ready':
+      return { ...state, setting: action.setting, position: action.position };
+    case 'reset':
+      return { ...initialGameState };
+    default:
+      return { ...state };
+  }
+}
+
+function useGameState() {
+  const state = useContext(GameStateContext);
+  if (!state) {
+    throw new Error('Provider not found');
+  }
+  return (state);
+}
+
+function useGameDispatch() {
+  const dispatch = useContext(GameDispatchContext);
+  if (!dispatch) {
+    throw new Error('Provider not found');
+  }
+  return (dispatch);
+}
+
+function GameContextProvider({ children }: { children: React.ReactNode }) {
+  const [appState, appDispatch] = useReducer(GameReducer, initialGameState);
+  return (
+    <GameStateContext.Provider value={appState}>
+      <GameDispatchContext.Provider value={appDispatch}>
+        {children}
+      </GameDispatchContext.Provider>
+    </GameStateContext.Provider>
+  );
+}
+
+export {
+  GameContextProvider, useGameDispatch, useGameState,
+};

--- a/src/utils/hooks/useMatch.tsx
+++ b/src/utils/hooks/useMatch.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Socket } from 'socket.io-client';
+import { toast } from 'react-toastify';
 import { useHistory } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -20,6 +22,13 @@ const useStyles = makeStyles({
   },
 });
 
+const offListeners = (socket: Socket | null) => {
+  socket?.off('ready');
+  socket?.off('duplicated');
+  socket?.off('declined');
+  socket?.off('canceled');
+};
+
 const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
   const { socket } = useAppState();
   const { mode } = useGameState();
@@ -33,6 +42,7 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
     player1: RawUserInfoType,
     gameSetting: any,
   ) => {
+    offListeners(socket);
     gameDispatch({
       type: 'ready',
       position,
@@ -40,36 +50,29 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
       player1: { ...player1, avatar: makeAPIPath(`/${player1.avatar}`) },
       setting: gameSetting,
     });
-    socket?.off('ready');
-    socket?.off('duplicated');
-    socket?.off('declined');
     setOpen(false);
     history.push(PLAY_PATH);
   };
 
   const handleExit = () => {
+    offListeners(socket);
     socket?.emit('leaveGame', { type: 'LADDER', mode });
     gameDispatch({ type: 'reset' });
-    socket?.off('ready');
-    socket?.off('duplicated');
     setOpen(false);
   };
 
   const handleDeclined = () => {
+    offListeners(socket);
+    toast.warn('매치 요청이 거절되었습니다.');
     gameDispatch({ type: 'reset' });
-    socket?.off('canceled');
-    socket?.off('ready');
-    socket?.off('declined');
     setOpen(false);
   };
 
   const handleCancel = (opponentId: string) => {
+    offListeners(socket);
     socket?.emit('cancelMatchInvitation', { opponentId });
-  };
-
-  const handleCanceled = () => {
-    handleDeclined();
-    // FIXME: toast
+    gameDispatch({ type: 'reset' });
+    setOpen(false);
   };
 
   const inviteUser = (gameMode: GameModeType, opponentId: string) => {
@@ -90,41 +93,50 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
       buttons: <Button onClick={() => handleCancel(opponentId)}>초대 취소</Button>,
       onClose: () => handleCancel(opponentId),
     });
-    // eslint-disable-next-line no-console
-    console.log('invite', opponentId);
     socket?.emit('inviteMatch', { mode: gameMode, opponentId });
-    // NOTE 왜 여기서 acceptMatch하면 되고 handleAccept에서 하면 안되지?
     socket?.on('ready', handleReady);
     socket?.on('declined', handleDeclined);
   };
 
-  const handleAccept = (gameMode: GameModeType, opponentId: string) => {
-    // eslint-disable-next-line no-console
-    console.log('accept match from', opponentId);
-    socket?.on('ready', handleReady);
-    socket?.emit('acceptMatch', { mode: gameMode, opponentId });
+  const handleAccept = (gameMode: GameModeType, opponentId: string, currentSocket: Socket) => {
+    currentSocket?.on('ready', handleReady);
+    currentSocket?.emit('acceptMatch', { mode: gameMode, opponentId });
+    currentSocket?.off('canceled');
   };
 
-  const handleDecline = (opponentId: string) => {
-    // eslint-disable-next-line no-console
-    console.log('decline match from', opponentId);
-    socket?.emit('declineMatch', { opponentId });
+  const handleDecline = (opponentId: string, currentSocket: Socket) => {
+    gameDispatch({ type: 'reset' });
+    currentSocket?.emit('declineMatch', { opponentId });
+    currentSocket?.off('canceled');
     setOpen(false);
   };
 
-  const handleInvited = (gameMode: GameModeType, id: string) => {
-    socket?.on('canceled', handleCanceled);
+  const handleCanceled = () => {
+    toast.warn('매치 요청이 취소되었습니다.');
+    gameDispatch({ type: 'reset' });
+    offListeners(socket);
+    setOpen(false);
+  };
+
+  const handleInvited = (gameMode: GameModeType, id: string, currentSocket: Socket) => {
+    gameDispatch({
+      type: 'setGame',
+      gameType: 'EXHIBITION',
+      mode: gameMode,
+      isPlayer: true,
+    });
+    currentSocket?.on('canceled', handleCanceled);
     setDialog({
       title: '매치 초대 알림',
       content: `${id}님으로부터 ${gameMode} 매치 초대가 도착하였습니다.
       수락하시겠습니까?`,
       buttons: (
         <>
-          <Button onClick={() => handleAccept(gameMode, id)}>confirm</Button>
-          <Button variant="outlined" onClick={() => handleDecline(id)}>decline</Button>
+          <Button onClick={() => handleAccept(gameMode, id, currentSocket)}>confirm</Button>
+          <Button variant="outlined" onClick={() => handleDecline(id, currentSocket)}>decline</Button>
         </>
       ),
-      onClose: () => handleDecline(id),
+      onClose: () => handleDecline(id, currentSocket),
     });
     setOpen(true);
   };

--- a/src/utils/hooks/useMatch.tsx
+++ b/src/utils/hooks/useMatch.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { makeStyles } from '@material-ui/core/styles';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import Grid from '@material-ui/core/Grid';
+import Typo from '../../components/atoms/Typo/Typo';
+import Button from '../../components/atoms/Button/Button';
+import { useAppState } from './useAppContext';
+import { useGameDispatch, useGameState } from './useGameContext';
+import { RawUserInfoType } from '../../types/Response';
+import { MatchPositionType, GameModeType } from '../../types/Match';
+import { makeAPIPath } from '../utils';
+import { SetOpenType, SetDialogType } from './useDialog';
+
+const PLAY_PATH = '/game/play';
+
+const useStyles = makeStyles({
+  progress: {
+    margin: '1em',
+  },
+});
+
+const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
+  const { socket } = useAppState();
+  const { mode } = useGameState();
+  const gameDispatch = useGameDispatch();
+  const classes = useStyles();
+  const history = useHistory();
+
+  const handleReady = (
+    position: MatchPositionType,
+    player0: RawUserInfoType,
+    player1: RawUserInfoType,
+    gameSetting: any,
+  ) => {
+    gameDispatch({
+      type: 'ready',
+      position,
+      player0: { ...player0, avatar: makeAPIPath(`/${player0.avatar}`) },
+      player1: { ...player1, avatar: makeAPIPath(`/${player1.avatar}`) },
+      setting: gameSetting,
+    });
+    socket?.off('ready');
+    socket?.off('duplicated');
+    socket?.off('declined');
+    setOpen(false);
+    history.push(PLAY_PATH);
+  };
+
+  const handleExit = () => {
+    socket?.emit('leaveGame', { type: 'LADDER', mode });
+    gameDispatch({ type: 'reset' });
+    socket?.off('ready');
+    socket?.off('duplicated');
+    setOpen(false);
+  };
+
+  const handleDeclined = () => {
+    gameDispatch({ type: 'reset' });
+    socket?.off('canceled');
+    socket?.off('ready');
+    socket?.off('declined');
+    setOpen(false);
+  };
+
+  const handleCancel = (opponentId: string) => {
+    socket?.emit('cancelMatchInvitation', { opponentId });
+  };
+
+  const handleCanceled = () => {
+    handleDeclined();
+    // FIXME: toast
+  };
+
+  const inviteUser = (gameMode: GameModeType, opponentId: string) => {
+    gameDispatch({
+      type: 'setGame',
+      gameType: 'EXHIBITION',
+      mode: gameMode,
+      isPlayer: true,
+    });
+    setDialog({
+      title: '매치 초대 수락 대기 중',
+      content: (
+        <Grid container direction="column" justifyContent="center" alignItems="center">
+          <CircularProgress size={100} className={classes.progress} aria-busy />
+          <Typo variant="subtitle1" align="center">매치 초대 후 수락 대기중입니다.</Typo>
+        </Grid>
+      ),
+      buttons: <Button onClick={() => handleCancel(opponentId)}>초대 취소</Button>,
+      onClose: () => handleCancel(opponentId),
+    });
+    // eslint-disable-next-line no-console
+    console.log('invite', opponentId);
+    socket?.emit('inviteMatch', { mode: gameMode, opponentId });
+    // NOTE 왜 여기서 acceptMatch하면 되고 handleAccept에서 하면 안되지?
+    socket?.on('ready', handleReady);
+    socket?.on('declined', handleDeclined);
+  };
+
+  const handleAccept = (gameMode: GameModeType, opponentId: string) => {
+    // eslint-disable-next-line no-console
+    console.log('accept match from', opponentId);
+    socket?.on('ready', handleReady);
+    socket?.emit('acceptMatch', { mode: gameMode, opponentId });
+  };
+
+  const handleDecline = (opponentId: string) => {
+    // eslint-disable-next-line no-console
+    console.log('decline match from', opponentId);
+    socket?.emit('declineMatch', { opponentId });
+    setOpen(false);
+  };
+
+  const handleInvited = (gameMode: GameModeType, id: string) => {
+    socket?.on('canceled', handleCanceled);
+    setDialog({
+      title: '매치 초대 알림',
+      content: `${id}님으로부터 ${gameMode} 매치 초대가 도착하였습니다.
+      수락하시겠습니까?`,
+      buttons: (
+        <>
+          <Button onClick={() => handleAccept(gameMode, id)}>confirm</Button>
+          <Button variant="outlined" onClick={() => handleDecline(id)}>decline</Button>
+        </>
+      ),
+      onClose: () => handleDecline(id),
+    });
+    setOpen(true);
+  };
+
+  return {
+    handleReady, handleExit, inviteUser, handleInvited,
+  };
+};
+
+export default useMatch;

--- a/src/utils/hooks/useMatch.tsx
+++ b/src/utils/hooks/useMatch.tsx
@@ -61,9 +61,9 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
     setOpen(false);
   };
 
-  const handleDeclined = () => {
+  const handleDeclined = ({ message }: { message: string }) => {
     offListeners(socket);
-    toast.warn('매치 요청이 거절되었습니다.');
+    toast.warn(message);
     gameDispatch({ type: 'reset' });
     setOpen(false);
   };
@@ -101,7 +101,6 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
   const handleAccept = (gameMode: GameModeType, opponentId: string, currentSocket: Socket) => {
     currentSocket?.on('ready', handleReady);
     currentSocket?.emit('acceptMatch', { mode: gameMode, opponentId });
-    currentSocket?.off('canceled');
   };
 
   const handleDecline = (opponentId: string, currentSocket: Socket) => {
@@ -111,14 +110,17 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
     setOpen(false);
   };
 
-  const handleCanceled = () => {
-    toast.warn('매치 요청이 취소되었습니다.');
+  const handleCanceled = ({ message }: { message: string }) => {
+    toast.warn(message);
     gameDispatch({ type: 'reset' });
     offListeners(socket);
     setOpen(false);
   };
 
-  const handleInvited = (gameMode: GameModeType, id: string, currentSocket: Socket) => {
+  const handleInvited = (
+    gameMode: GameModeType, opponent: RawUserInfoType, currentSocket: Socket,
+  ) => {
+    const { id, name } = opponent;
     gameDispatch({
       type: 'setGame',
       gameType: 'EXHIBITION',
@@ -128,7 +130,7 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
     currentSocket?.on('canceled', handleCanceled);
     setDialog({
       title: '매치 초대 알림',
-      content: `${id}님으로부터 ${gameMode} 매치 초대가 도착하였습니다.
+      content: `${name}님으로부터 ${gameMode} 매치 초대가 도착하였습니다.
       수락하시겠습니까?`,
       buttons: (
         <>

--- a/src/utils/hooks/useMatch.tsx
+++ b/src/utils/hooks/useMatch.tsx
@@ -54,8 +54,6 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
   };
 
   const handleExit = (mode: GameModeType | null) => {
-    // eslint-disable-next-line no-console
-    console.log('exit', mode);
     offListeners(socket);
     socket?.emit('leaveGame', { type: 'LADDER', mode });
     gameDispatch({ type: 'reset' });

--- a/src/utils/hooks/useMatch.tsx
+++ b/src/utils/hooks/useMatch.tsx
@@ -80,7 +80,7 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
       gameType: 'EXHIBITION',
       mode,
       isPlayer: true,
-    });
+    }); // FIXME: 여기서 Dispatch하면 안 됨 -> 수락했을 때 Dispatch
     setDialog({
       title: '매치 초대 수락 대기 중',
       content: (
@@ -98,6 +98,12 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
   };
 
   const handleAccept = (mode: GameModeType, opponentId: string, currentSocket: Socket) => {
+    gameDispatch({
+      type: 'setGame',
+      gameType: 'EXHIBITION',
+      mode,
+      isPlayer: true,
+    });
     currentSocket?.on('ready', handleReady);
     currentSocket?.emit('acceptMatch', { mode, opponentId });
   };
@@ -120,12 +126,6 @@ const useMatch = (setOpen: SetOpenType, setDialog: SetDialogType) => {
     mode: GameModeType, opponent: RawUserInfoType, currentSocket: Socket,
   ) => {
     const { id, name } = opponent;
-    gameDispatch({
-      type: 'setGame',
-      gameType: 'EXHIBITION',
-      mode,
-      isPlayer: true,
-    });
     currentSocket?.on('canceled', handleCanceled);
     setDialog({
       title: '매치 초대 알림',

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,3 @@
+export const MAIN_GAME_PAGE = '/game';
+export const PLAY_PATH = '/game/play';
+export const WATCH_PATH = '/game/watch';

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -19,6 +19,8 @@ const errorMessageHandler = (error: any) => {
 
 const makeDateString = (date: Date) => `${date.getFullYear()}.${date.getMonth() + 1}.${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
 
+const makeMatchHistoryString = (score: number, win: number, lose: number): string => (`${score}점 / ${win}승 ${lose}패`);
+
 export {
-  makeAPIPath, asyncGetRequest, errorMessageHandler, makeDateString,
+  makeAPIPath, asyncGetRequest, errorMessageHandler, makeDateString, makeMatchHistoryString,
 };


### PR DESCRIPTION
본 PR의 일부는 @PennyBlack2008 님과 VSCode LiveShare로 피어 프로그래밍 하였습니다.

## 기능에 대한 설명

- 게임 플레이 로직이 포함된 GamePlayPage를 작성하였습니다.
- gameContext를 별도 작성하였고, 게임 정보와 관련된 로직을 Context API로 관리합니다.
<br>

- ChatMessage, ProfileCard 컴포넌트에 매치 초대 기능을 추가하였습니다.
- ProfilePage에서 매치 초대 기능을 추가하였습니다.
- 매치 관련 로직을 여러 컴포넌트에서 사용할 수 있도록 useMatch 커스텀 훅을 작성하였습니다.
<br>

- GameWatchPage에 관전 기능을 추가하였습니다.
<br>

- 로그인 로직 변경에 따라 2FA 로그인 로직을 수정했습니다. (1d3979f4c8ae52427ea1120f306191adb7b3e963) 이 내용은 해당 PR에 포함되기에 적절하지 않은 듯하나 새로운 브랜치에서 작업하기 어려운 상황이었기 때문에 팀 내부 협의 후 해당 브랜치에 커밋하였습니다.

## 테스트 (Optional)
- [x] docker-compose로 API 연동 확인

## REFERENCE (Optional)
### Mui의 Dialog를 특정 요소 내부에 표시
- [Material UI React Modal Dialog on custom container](https://stackoverflow.com/questions/49236761/material-ui-react-modal-dialog-on-custom-container) / [추가 참고](https://stackoverflow.com/questions/49236761/material-ui-react-modal-dialog-on-custom-container#comment97682787_49245765)
- [Mui Modal component](https://v4.mui.com/components/modal/)

## ISSUE
close #108
close #74 