### PR TITLE
Fix: ChatPage에서 채팅 목록을 정상적으로 로딩하지 못하는 문제 해결

### DIFF
--- a/src/components/pages/ChannelManagePage/ChannelManagePage.tsx
+++ b/src/components/pages/ChannelManagePage/ChannelManagePage.tsx
@@ -69,7 +69,7 @@ const ChannelManagePage = ({ match }: RouteComponentProps<MatchParams>) => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => prev + 1);
     observer.observe(entry.target);
   });

--- a/src/components/pages/ChannelPage/ChannelPage.tsx
+++ b/src/components/pages/ChannelPage/ChannelPage.tsx
@@ -77,7 +77,7 @@ const ChannelList = ({ type }: ListProps) => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => prev + 1);
     observer.observe(entry.target);
   });

--- a/src/components/pages/ChatPage/ChatPage.tsx
+++ b/src/components/pages/ChatPage/ChatPage.tsx
@@ -43,14 +43,12 @@ const ChatPage = () => {
   const [page, setPage] = useState<number>(0);
   const isSending = useRef<boolean>(false);
   const [members, setMembers] = useState<MemberType[]>([]);
-  const {
-    chatting, newMessage, blockList,
-  } = useAppState();
   const appDispatch = useAppDispatch();
+  const location = useLocation();
+  const { chatting, newMessage, blockList } = useAppState();
   const {
     isOpen, setOpen, dialog, setDialog,
   } = useDialog();
-  const location = useLocation();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setChat(e.target.value);
@@ -75,6 +73,7 @@ const ChatPage = () => {
     const path = chatting.type === 'channel' ? makeAPIPath(`/channels/${chatting.name}/chats`) : makeAPIPath(`/dms/opposite/${chatting.name}`);
 
     asyncGetRequest(`${path}?perPage=${COUNTS_PER_PAGE}&page=${page}`, source)
+      .finally(() => appDispatch({ type: 'endLoading' }))
       .then(({ data }) => {
         const typed: MessageType[] = data
           .map((one: RawMessageType | RawDMType) => (
@@ -91,21 +90,31 @@ const ChatPage = () => {
   };
 
   useEffect(() => {
+    if (chatting) appDispatch({ type: 'loading' });
     setChats([]);
     isSending.current = false;
     setChat('');
-    setPage(chatting ? 1 : 0);
-    setChatEnd(!chatting);
-    source.cancel();
+    setPage(-1);
+    setChatEnd(true);
     if (chatting && chatting.type === 'channel') {
       asyncGetRequest(makeAPIPath(`/channels/${chatting.name}/members`))
         .then(({ data }) => { setMembers(data); })
         .catch((error) => { errorMessageHandler(error); });
     } else setMembers([]);
+
+    return () => {
+      source.cancel();
+      setPage(-1);
+      setChatEnd(true);
+    };
   }, [chatting]);
 
   useEffect(() => {
-    fetchItems();
+    if (page > 0) fetchItems();
+    else {
+      setPage(0);
+      setChatEnd(false);
+    }
   }, [page]);
 
   useEffect(() => {
@@ -138,8 +147,8 @@ const ChatPage = () => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    setPage((prev) => prev + 1);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    setPage((prev) => (isChatEnd ? prev : prev + 1));
     observer.observe(entry.target);
   });
 

--- a/src/components/pages/ChatPage/ChatPage.tsx
+++ b/src/components/pages/ChatPage/ChatPage.tsx
@@ -147,7 +147,7 @@ const ChatPage = () => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => (isChatEnd ? prev : prev + 1));
     observer.observe(entry.target);
   });

--- a/src/components/pages/CommunityPage/CommunityPage.tsx
+++ b/src/components/pages/CommunityPage/CommunityPage.tsx
@@ -70,7 +70,7 @@ const UserList = ({ type }: ListProps) => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => prev + 1);
     observer.observe(entry.target);
   });

--- a/src/components/pages/DMPage/DMPage.tsx
+++ b/src/components/pages/DMPage/DMPage.tsx
@@ -81,7 +81,7 @@ const DMPage = () => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => prev + 1);
     observer.observe(entry.target);
   });

--- a/src/components/pages/GameWatchPage/GameWatchPage.tsx
+++ b/src/components/pages/GameWatchPage/GameWatchPage.tsx
@@ -81,7 +81,7 @@ const MatchList = ({ type }: ListProps) => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => prev + 1);
     observer.observe(entry.target);
   });

--- a/src/components/pages/ProfilePage/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage/ProfilePage.tsx
@@ -74,7 +74,7 @@ const MatchHistory = ({ username }: UserNameType) => {
   // eslint-disable-next-line no-unused-vars
   const [_, setRef] = useIntersect(async (entry: any, observer: any) => {
     observer.unobserve(entry.target);
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 10));
     setPage((prev) => prev + 1);
     observer.observe(entry.target);
   });


### PR DESCRIPTION
## 기능에 대한 설명
#115 issue에 작성한 것과 같은 문제가 있어, 채팅 페이지를 이동할 때 page를 -1, isChatEnd를 true로 세팅한 후 page 값이 -1으로 바뀐 것을 확인한 뒤 목록을 로딩하도록 로직을 변경하였습니다. 
- 제가 확인한 바로는 전과 같은 문제가 발생하지 않았으나, 혹시라도 @PennyBlack2008 님의 환경에서 문제가 발생하지는 않는지 확인 부탁드립니다.
- 추가로 infinite scroll에 사용되는 callback 함수 내부 setTimeout의 시간을 기존의 250ms에서 10ms로 조정했는데, 관련된 문제는 없는지 확인 부탁드립니다.

## 테스트 (Optional)
- [x] docker-compose로 API 연동 테스트

## REFERENCE (Optional)
참고한 레퍼런스를 기재해주세요.

## ISSUE

fix #115