### PR TITLE
Fix: 프로필 수정에서 2FA 활성화 여부가 변경되지 않는 문제 해결

### DIFF
--- a/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
+++ b/src/components/organisms/ChannelInfoForm/ChannelInfoForm.tsx
@@ -140,7 +140,7 @@ const ChannelInfoForm = ({ setOpen, channel }: ChannelInfoFormProps) => {
           } else toast.error('입력값이 잘못되었습니다. 다시 확인해주세요.');
         } else errorMessageHandler(error);
       });
-  }, [channelName, isToggleChecked, checkPassword]);
+  }, [channelName, isToggleChecked, checkPassword, appState.channels, appState.socket]);
 
   const handleEdit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/src/components/organisms/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/organisms/UserInfoForm/UserInfoForm.tsx
@@ -214,7 +214,7 @@ const UserInfoForm = ({
           } else toast.error('입력값이 잘못되었습니다. 다시 확인해주세요.');
         } else errorMessageHandler(error);
       });
-  }, [imageFile, username, is2FAEnabled]);
+  }, [imageFile, username, is2FAEnabled, is2FAChanged]);
 
   const isValidForm = useCallback(() => {
     if (is2FAChanged) {


### PR DESCRIPTION
## 기능에 대한 설명

프로필 수정에서 2FA 활성화 여부가 변경되지 않는 문제가 있었는데, App 렌더링 최적화(#118)를 진행하며 useCallback의 deps에서 함수에 사용되는 변수를 누락한 것이 원인이었습니다. deps에 누락된 변수를 추가하여 해결해주었습니다.

## 테스트 (Optional)

- [x] docker-compose로 API 연동 확인

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE

fix #120 