### PR TITLE
Fix: 채널 관리 페이지에서 목록 순서가 바뀌는 현상 해결

### DIFF
--- a/src/components/pages/ChannelManagePage/ChannelManagePage.tsx
+++ b/src/components/pages/ChannelManagePage/ChannelManagePage.tsx
@@ -125,8 +125,11 @@ const ChannelManagePage = ({ match }: RouteComponentProps<MatchParams>) => {
             myRole={role as ('ADMIN' | 'OWNER')}
             setUser={(userInfo) => {
               if (userInfo.memberships[0].role === 'NONE') {
-                setUsers(users.filter((one) => one.id !== userInfo.id));
-              } else setUsers(users.filter((one) => one.id !== userInfo.id).concat(userInfo));
+                setUsers((prev) => (prev.filter((one) => one.id !== userInfo.id)));
+              } else {
+                setUsers((prev) => (prev.map((one) => (
+                  one.id !== userInfo.id ? one : userInfo))));
+              }
             }}
             setOpen={setOpen}
             setDialog={setDialog}


### PR DESCRIPTION
## 기능에 대한 설명
`ChannelManagePage`에서 `ChannelUserListItem`에 넘겨주는 `setUser` props를 수정하였습니다.
1. 상태가 갱신된 유저의 ListItem이 가장 아래로 이동하는 현상  
    - 기존에는 상태가 바뀐 요소를 concat을 통해 array 가장 뒷부분에 붙여주었는데, map을 이용하는 방식으로 변경하여 배열의 순서를 유지하도록 하였습니다.
2. 상태가 갱신된 유저 외에 다른 유저의 상태를 변경시키면 최신 상태를 불러오지 못하는 현상
    - 기존에는 prev를 사용하지 않고 users를 불러와 사용했기 때문에 최신 상태를 트래킹하지 못하고 있었는데, prev를 참조하는 방식으로 변경하였습니다.

## 테스트 (Optional)

- docker-compose로 API 연동 확인(채널에 유저 추가 후 뮤트/뮤트 해제, 관리 임명/해제, 차단/차단 해제 테스트)

## REFERENCE (Optional)

참고한 레퍼런스를 기재해주세요.

## ISSUE

fix #127